### PR TITLE
correct recordPrefixIdx

### DIFF
--- a/rowcodec/encoder.go
+++ b/rowcodec/encoder.go
@@ -300,7 +300,7 @@ var defaultStmtCtx = &stmtctx.StatementContext{
 
 const (
 	rowKeyLen       = 19
-	recordPrefixIdx = 1
+	recordPrefixIdx = 10
 )
 
 func IsRowKey(key []byte) bool {

--- a/rowcodec/rowcodec_test.go
+++ b/rowcodec/rowcodec_test.go
@@ -44,6 +44,14 @@ func (s *testSuite) TestRowCodec(c *C) {
 	}
 }
 
+func (s *testSuite) TestIsRowKey(c *C) {
+	rowKey := tablecodec.EncodeRowKeyWithHandle(1, 1)
+	c.Assert(IsRowKey(rowKey), IsTrue)
+
+	indexKey := tablecodec.EncodeIndexSeekKey(1, 2, []byte{1})
+	c.Assert(IsRowKey(indexKey), IsFalse)
+}
+
 func BenchmarkEncode(b *testing.B) {
 	b.ReportAllocs()
 	oldRow := types.MakeDatums(1, "abc", 1.1)


### PR DESCRIPTION
rowkey format is `t{8 bytes id}_r{8 bytes id}`.

`IsRowKey` used by `Prewrite`, the incorrect result cause it never convert value to new row format.