### PR TITLE
fix delete panic

### DIFF
--- a/tikv/mvcc.go
+++ b/tikv/mvcc.go
@@ -679,10 +679,10 @@ type GCCompactionFilter struct {
 
 // (old key first byte) = (latest key first byte) + 1
 const (
-	metaPrefix     byte = 'm'
+	metaPrefix byte = 'm'
 	// 'm' + 1 = 'n'
-	metaOldPrefix  byte = 'n'
-	tablePrefix    byte = 't'
+	metaOldPrefix byte = 'n'
+	tablePrefix   byte = 't'
 	// 't' + 1 = 'u
 	tableOldPrefix byte = 'u'
 )


### PR DESCRIPTION
The bug is caused by concurrently deleting the same key in lockStore, triggered in this scenario:

1. A region `X` is split into `X1` and `X2`.
2. The old region `X` is being referenced by a  Commit command.
3. Before Commit command finished, `X1` is split again, into `X11` and `X12`.
4. The Commit command retried due to timeout, sent to `X11`.

The cause is that the retried Commit command locks keys in `X11`, the original Commit command locks keys in `X`, they don't block each other.

We make sure a region's parent's latch is clear before using the child region, but we didn't prevent it from splitting.
When `X1` is split again, its refCount decreased to 0, so the region `X11` can be accessed, its parent's latch is clear, but its grandparent's latch is not clear, so there would be concurrent deletion on the same key, cause panic.