### PR TITLE
port SstFileWriter from RocksDB

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/ngaut/unistore
 
 require (
 	github.com/BurntSushi/toml v0.3.1
+	github.com/DataDog/zstd v1.3.5
 	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
 	github.com/coocood/badger v1.5.1-0.20181229021924-c02c9aba9c41
@@ -19,6 +20,7 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.1
 	github.com/ngaut/log v0.0.0-20180314031856-b8e36e7ba5ac
 	github.com/opentracing/opentracing-go v1.0.2
+	github.com/pierrec/lz4 v2.0.5+incompatible
 	github.com/pingcap/check v0.0.0-20181213055612-5c2b07721bdb
 	github.com/pingcap/errors v0.11.0
 	github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e
@@ -26,6 +28,7 @@ require (
 	github.com/pingcap/parser v0.0.0-20181218071912-deacf026787e
 	github.com/pingcap/tidb v0.0.0-20181130082510-08f0168a6cae
 	github.com/pingcap/tipb v0.0.0-20181012112600-11e33c750323
+	github.com/pkg/errors v0.8.0
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v0.9.0
 	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DataDog/zstd v1.3.5 h1:DtpNbljikUepEPD16hD4LvIcmhnhdLTiW/5pHgbmp14=
+github.com/DataDog/zstd v1.3.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -91,6 +93,8 @@ github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2 h1:3jA2P6O1F9UOrWVpwrIo17pu01KWvNWg4X946/Y5Zwg=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
+github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pingcap/check v0.0.0-20171206051426-1c287c953996/go.mod h1:B1+S9LNcuMyLH/4HMTViQOJevkGiik3wW2AN9zb2fNQ=
 github.com/pingcap/check v0.0.0-20181213055612-5c2b07721bdb/go.mod h1:B1+S9LNcuMyLH/4HMTViQOJevkGiik3wW2AN9zb2fNQ=
 github.com/pingcap/errors v0.11.0 h1:DCJQB8jrHbQ1VVlMFIrbj2ApScNNotVmkSNplu2yUt4=

--- a/rocksdb/block_based_table_builder.go
+++ b/rocksdb/block_based_table_builder.go
@@ -1,3 +1,12 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
 package rocksdb
 
 import (

--- a/rocksdb/block_based_table_builder.go
+++ b/rocksdb/block_based_table_builder.go
@@ -1,0 +1,336 @@
+package rocksdb
+
+import (
+	"math"
+	"os"
+
+	"github.com/coocood/badger/fileutil"
+	"github.com/coocood/badger/y"
+)
+
+const (
+	propsBlockHandleKey = "rocksdb.properties"
+	bloomBlockHandleKey = "fullfilter.rocksdb.BuiltinBloomFilter"
+)
+
+type BlockBasedTableBuilder struct {
+	props      TableProperties
+	writer     *fileutil.BufferedFileWriter
+	comparator Comparator
+
+	dataBlockBuilder  *blockBuilder
+	indexBlockBuilder *indexBlockBuilder
+	filterBuilder     *fullFilterBlockBuilder
+
+	offset        uint64
+	pendingHandle blockHandle
+	lastKey       []byte
+
+	opts *BlockBasedTableOptions
+
+	blockSizeDeviationLimit int
+	alignment               int
+}
+
+func NewBlockBasedTableBuilder(f *os.File, opts *BlockBasedTableOptions) *BlockBasedTableBuilder {
+	w := fileutil.NewBufferedFileWriter(f, opts.BufferSize, opts.BytesPerSync, opts.RateLimiter)
+	blockSizeDeviationLimit := ((opts.BlockSize * (100 - opts.BlockSizeDeviation)) + 99) / 100
+	alignment := 4 * 1024
+	if opts.BlockSize < alignment {
+		alignment = opts.BlockSize
+	}
+
+	return &BlockBasedTableBuilder{
+		writer:                  w,
+		comparator:              opts.Comparator,
+		dataBlockBuilder:        newBlockBuilder(opts.BlockRestartInterval),
+		indexBlockBuilder:       newIndexBlockBuilder(opts.IndexBlockRestartInterval),
+		filterBuilder:           newFullFilterBlockBuilder(opts),
+		opts:                    opts,
+		blockSizeDeviationLimit: blockSizeDeviationLimit,
+		alignment:               alignment,
+	}
+}
+
+func (b *BlockBasedTableBuilder) Add(key, value []byte) error {
+	var ikey internalKey
+	ikey.Decode(key)
+
+	// We don't support other record types.
+	y.Assert(ikey.ValueType.IsValue())
+
+	if b.shouldFlush(key, value) {
+		if err := b.flush(); err != nil {
+			return err
+		}
+		b.indexBlockBuilder.AddIndexEntry(b.lastKey, &b.pendingHandle)
+	}
+
+	b.filterBuilder.Add(extractUserKey(key))
+
+	b.dataBlockBuilder.Add(key, value)
+	b.props.NumEntries++
+	b.props.RawKeySize += uint64(len(key))
+	b.props.RawValueSize += uint64(len(value))
+	b.lastKey = y.SafeCopy(b.lastKey, key)
+
+	return nil
+}
+
+const (
+	blockBasedTableMagicNumber = 0x88e241b785f4cff7
+	maxBlockHandleLength       = 10 + 10 // two varint64
+	footerEncodedLength        = 1 + 2*maxBlockHandleLength + 4 + 8
+)
+
+func (b *BlockBasedTableBuilder) Finish() error {
+	if err := b.flush(); err != nil {
+		return err
+	}
+
+	if b.dataBlockBuilder.Empty() {
+		b.indexBlockBuilder.AddIndexEntry(b.lastKey, &b.pendingHandle)
+	}
+
+	// Write meta blocks and metaindex block with the following order.
+	//    1. [meta block: filter]
+	//    2. [meta block: index]
+	//    3. [meta block: properties]
+	//    4. [metaindex block]
+	var metaIndexBlockHandle, indexBlockHandle blockHandle
+	metaIndexBuilder := newMetaIndexBuilder()
+	if err := b.writeFilterBlock(metaIndexBuilder); err != nil {
+		return err
+	}
+	if err := b.writeIndexBlock(&indexBlockHandle); err != nil {
+		return err
+	}
+	if err := b.writePropsBlock(metaIndexBuilder); err != nil {
+		return err
+	}
+	if err := b.writeRawBlock(metaIndexBuilder.Finish(), CompressionNone, &metaIndexBlockHandle, false); err != nil {
+		return err
+	}
+
+	// Write footer
+	var footerBuf [footerEncodedLength]byte
+	cursor := 0
+	footerBuf[cursor] = byte(b.opts.ChecksumType)
+	cursor += 1
+	cursor += metaIndexBlockHandle.EncodeTo(footerBuf[cursor:])
+	cursor += indexBlockHandle.EncodeTo(footerBuf[cursor:])
+	cursor = footerEncodedLength - 12
+	rocksEndian.PutUint32(footerBuf[cursor:], 2)
+	cursor += 4
+	rocksEndian.PutUint32(footerBuf[cursor:], blockBasedTableMagicNumber&0xffffffff)
+	cursor += 4
+	rocksEndian.PutUint32(footerBuf[cursor:], blockBasedTableMagicNumber>>32)
+
+	if err := b.writer.Append(footerBuf[:]); err != nil {
+		return err
+	}
+	b.offset += uint64(len(footerBuf))
+	return b.writer.Flush(true)
+}
+
+func (b *BlockBasedTableBuilder) flush() error {
+	if b.dataBlockBuilder.Empty() {
+		return nil
+	}
+	if err := b.writeBlock(b.dataBlockBuilder.Finish(), &b.pendingHandle, true); err != nil {
+		return err
+	}
+
+	b.props.DataSize = b.offset
+	b.props.NumDataBlocks += 1
+	b.dataBlockBuilder.Reset()
+
+	return nil
+}
+
+func (b *BlockBasedTableBuilder) writeFilterBlock(metaIndexBuilder *metaIndexBuilder) error {
+	if b.filterBuilder.Empty() {
+		return nil
+	}
+
+	var filterBlockHandle blockHandle
+	contents := b.filterBuilder.Finish()
+	b.props.FilterSize += uint64(len(contents))
+	if err := b.writeRawBlock(contents, CompressionNone, &filterBlockHandle, false); err != nil {
+		return err
+	}
+	metaIndexBuilder.AddHandle(bloomBlockHandleKey, &filterBlockHandle)
+
+	return nil
+}
+
+func (b *BlockBasedTableBuilder) writeIndexBlock(indexBlockHandle *blockHandle) error {
+	contents := b.indexBlockBuilder.Finish()
+	if b.opts.EnableIndexCompression {
+		return b.writeBlock(contents, indexBlockHandle, false)
+	}
+	return b.writeRawBlock(contents, CompressionNone, indexBlockHandle, false)
+}
+
+func (b *BlockBasedTableBuilder) writePropsBlock(metaIndexBuilder *metaIndexBuilder) error {
+	b.setupProperties()
+	p := &b.props
+	var handle blockHandle
+	propsBuilder := newPropsBlockBuilder()
+	for _, f := range b.opts.PropsInjectors {
+		f(propsBuilder)
+	}
+	propsBuilder.AddUint64(propColumnFamilyId, p.ColumnFamilyID)
+	propsBuilder.AddString(propCompression, p.CompressionName)
+	propsBuilder.AddUint64(propCreationTime, p.CreationTime)
+	propsBuilder.AddUint64(propDataSize, p.DataSize)
+	if p.FilterSize != 0 {
+		propsBuilder.AddString(propFilterPolicy, p.FilterPolicyName)
+		propsBuilder.AddUint64(propFilterSize, p.FilterSize)
+	}
+	propsBuilder.AddUint64(propFixedKeyLength, 0)
+	propsBuilder.AddUint64(propFormatVersion, 2)
+	propsBuilder.AddUint64(propIndexKeyIsUserKey, 0)
+	propsBuilder.AddUint64(propIndexSize, p.IndexSize)
+	propsBuilder.AddUint64(propNumDataBlocks, p.NumDataBlocks)
+	propsBuilder.AddUint64(propNumEntries, p.NumEntries)
+	propsBuilder.AddUint64(propOldestKeyTime, p.OldestKeyTime)
+	if p.PrefixExtractorName != "" {
+		propsBuilder.AddString(propPrefixExtractorName, p.PrefixExtractorName)
+	}
+	propsBuilder.AddUint64(propRawKeySize, p.RawKeySize)
+	propsBuilder.AddUint64(propRawValueSize, p.RawValueSize)
+
+	contents := propsBuilder.Finish()
+	if err := b.writeRawBlock(contents, CompressionNone, &handle, false); err != nil {
+		return err
+	}
+	metaIndexBuilder.AddHandle(propsBlockHandleKey, &handle)
+
+	return nil
+}
+
+func (b *BlockBasedTableBuilder) setupProperties() {
+	p := &b.props
+	p.ColumnFamilyID = math.MaxInt32
+	p.ColumnFamilyName = ""
+	p.FilterPolicyName = "rocksdb.BuiltinBloomFilter"
+	p.IndexSize = uint64(b.indexBlockBuilder.IndexSize() + blockTrailerSize)
+	p.CompressionName = b.opts.CompressionType.String()
+	p.CreationTime = b.opts.CreationTime
+	p.OldestKeyTime = b.opts.OldestKeyTime
+	p.PrefixExtractorName = b.opts.PrefixExtractorName
+}
+
+// Some compression libraries fail when the raw size is bigger than int. If
+// uncompressed size is bigger than kCompressionSizeLimit, don't compress it
+const compressionSizeLimit = math.MaxInt64
+
+func (b *BlockBasedTableBuilder) writeBlock(blockContents []byte, handle *blockHandle, isDataBlock bool) error {
+	var compressed bool
+	tp := b.opts.CompressionType
+	if len(blockContents) < compressionSizeLimit {
+		blockContents, compressed = CompressBlock(blockContents, b.opts.CompressionType)
+		if !compressed {
+			tp = CompressionNone
+		}
+	}
+	return b.writeRawBlock(blockContents, tp, handle, isDataBlock)
+}
+
+func (b *BlockBasedTableBuilder) writeRawBlock(contents []byte, tp CompressionType, handle *blockHandle, isDataBlock bool) error {
+	handle.Size = uint64(len(contents))
+	handle.Offset = b.offset
+	if err := b.writer.Append(contents); err != nil {
+		return err
+	}
+
+	var trailer [blockTrailerSize]byte
+	trailer[0] = byte(tp)
+	switch b.opts.ChecksumType {
+	case ChecksumNone:
+		rocksEndian.PutUint32(trailer[1:], 0)
+	case ChecksumCRC32:
+		crc := newCrc32()
+		crc.Write(contents)
+		crc.Write(trailer[0:1])
+		rocksEndian.PutUint32(trailer[1:], maskCrc32(crc.Sum32()))
+	case ChecksumXXHash:
+		panic("unsupported")
+	}
+	if err := b.writer.Append(trailer[:]); err != nil {
+		return err
+	}
+	b.offset += uint64(len(contents) + blockTrailerSize)
+
+	if b.opts.BlockAlign && isDataBlock {
+		pad := (b.alignment - ((len(contents) + blockTrailerSize) & (b.alignment - 1))) & (b.alignment - 1)
+		if err := b.writer.Append(make([]byte, pad)); err != nil {
+			return err
+		}
+		b.offset += uint64(pad)
+	}
+
+	return nil
+}
+
+func (b *BlockBasedTableBuilder) shouldFlush(key, value []byte) bool {
+	currSz := b.dataBlockBuilder.EstimateSize()
+	if currSz == 0 {
+		return false
+	}
+	if currSz >= b.opts.BlockSize {
+		return true
+	}
+
+	newEstimatedSz := b.dataBlockBuilder.EstimateSizeAfterKV(key, value)
+
+	if b.opts.BlockAlign {
+		newEstimatedSz += blockTrailerSize
+		return newEstimatedSz > b.opts.BlockSize
+	}
+	return newEstimatedSz > b.opts.BlockSize && currSz > b.blockSizeDeviationLimit
+}
+
+// Note: now assume format_version == 2
+type indexBlockBuilder struct {
+	blockBuilder blockBuilder
+	indexSize    int
+}
+
+func newIndexBlockBuilder(restartInterval int) *indexBlockBuilder {
+	b := new(indexBlockBuilder)
+	b.blockBuilder.Init(restartInterval)
+	return b
+}
+
+func (b *indexBlockBuilder) AddIndexEntry(lastKey []byte, handle *blockHandle) {
+	b.blockBuilder.Add(lastKey, handle.Encode())
+}
+
+func (b *indexBlockBuilder) IndexSize() int {
+	return b.indexSize
+}
+
+func (b *indexBlockBuilder) Finish() []byte {
+	contents := b.blockBuilder.Finish()
+	b.indexSize = len(contents)
+	return contents
+}
+
+type metaIndexBuilder struct {
+	blockBuilder blockBuilder
+}
+
+func newMetaIndexBuilder() *metaIndexBuilder {
+	b := new(metaIndexBuilder)
+	b.blockBuilder.Init(1)
+	return b
+}
+func (b *metaIndexBuilder) AddHandle(key string, handle *blockHandle) {
+	b.blockBuilder.Add([]byte(key), handle.Encode())
+}
+
+func (b *metaIndexBuilder) Finish() []byte {
+	return b.blockBuilder.Finish()
+}

--- a/rocksdb/block_builder.go
+++ b/rocksdb/block_builder.go
@@ -1,3 +1,12 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
 package rocksdb
 
 import "github.com/coocood/badger/y"

--- a/rocksdb/block_builder.go
+++ b/rocksdb/block_builder.go
@@ -1,0 +1,95 @@
+package rocksdb
+
+import "github.com/coocood/badger/y"
+
+// 1-byte type + 32-bit crc
+const blockTrailerSize = 5
+
+// blockBuilder port from RocksDB's blockBuilder without Hash Index Support
+type blockBuilder struct {
+	restartInterval int
+	counter         int
+	estimate        int
+	restarts        []uint32
+	buf             []byte
+	lastKey         []byte
+}
+
+func newBlockBuilder(restartInterval int) *blockBuilder {
+	b := new(blockBuilder)
+	b.Init(restartInterval)
+	return b
+}
+
+func (b *blockBuilder) Init(restartInterval int) {
+	b.restartInterval = restartInterval
+	b.restarts = []uint32{0}
+}
+
+func (b *blockBuilder) Reset() {
+	b.counter = 0
+	b.estimate = 0
+	b.buf = b.buf[:0]
+	b.restarts = b.restarts[:1]
+	b.lastKey = b.lastKey[:0]
+}
+
+func (b *blockBuilder) Add(key, value []byte) {
+	y.Assert(b.counter <= b.restartInterval)
+	var prefixLen uint32
+	if b.counter >= b.restartInterval {
+		// Restart compression
+		b.restarts = append(b.restarts, uint32(len(b.buf)))
+		b.counter = 0
+		b.lastKey = y.SafeCopy(b.lastKey, key)
+	} else {
+		prefixLen = uint32(differenceOffset(key, b.lastKey))
+		b.lastKey = y.SafeCopy(b.lastKey, key)
+	}
+
+	currSz := len(b.buf)
+
+	b.buf = appendVarint32(b.buf, prefixLen)
+	b.buf = appendVarint32(b.buf, uint32(len(key))-prefixLen)
+	b.buf = appendVarint32(b.buf, uint32(len(value)))
+
+	b.buf = append(b.buf, key[prefixLen:]...)
+	b.buf = append(b.buf, value...)
+
+	b.counter++
+	b.estimate += len(b.buf) - currSz
+}
+
+func (b *blockBuilder) Empty() bool {
+	return len(b.buf) == 0
+}
+
+func (b *blockBuilder) Finish() []byte {
+	var encodeBuf [4]byte
+	for _, restart := range b.restarts {
+		rocksEndian.PutUint32(encodeBuf[:], restart)
+		b.buf = append(b.buf, encodeBuf[:]...)
+	}
+	rocksEndian.PutUint32(encodeBuf[:], uint32(len(b.restarts)))
+	return append(b.buf, encodeBuf[:]...)
+}
+
+func (b *blockBuilder) EstimateSize() int {
+	return b.estimate
+}
+
+func (b *blockBuilder) EstimateSizeAfterKV(key, value []byte) int {
+	estimate := b.EstimateSize()
+	estimate += len(key) + len(value)
+
+	if b.counter >= b.restartInterval {
+		// a new restart entry
+		estimate += 4
+	}
+
+	// Note: this is an imprecise estimate as we will have to encoded size, one
+	// for shared key and one for non-shared key.
+	estimate += 4 + 4 + 4
+
+	return estimate
+}

--- a/rocksdb/compression.go
+++ b/rocksdb/compression.go
@@ -1,0 +1,75 @@
+package rocksdb
+
+import (
+	"math"
+
+	"github.com/DataDog/zstd"
+	"github.com/golang/snappy"
+	"github.com/pierrec/lz4"
+)
+
+func snappyCompress(input []byte) []byte {
+	outputBound := snappy.MaxEncodedLen(len(input))
+	output := make([]byte, outputBound)
+	return snappy.Encode(output, input)
+}
+
+func lz4Compress(input []byte) []byte {
+	rawLen := len(input)
+	if rawLen > math.MaxUint32 {
+		return nil
+	}
+
+	var varintBuf [5]byte
+	decompressedSize := encodeVarint32(varintBuf[:], uint32(rawLen))
+	outputBound := lz4.CompressBlockBound(rawLen)
+	output := make([]byte, len(decompressedSize)+outputBound)
+	copy(output, decompressedSize)
+	var ht [1 << 16]int
+	n, err := lz4.CompressBlock(input, output[len(decompressedSize):], ht[:])
+	if err != nil || n == 0 {
+		return nil
+	}
+	return output[:len(decompressedSize)+n]
+}
+
+func zstdCompress(input []byte) []byte {
+	rawLen := len(input)
+	if rawLen > math.MaxUint32 {
+		return nil
+	}
+
+	var varintBuf [5]byte
+	decompressedSize := encodeVarint32(varintBuf[:], uint32(rawLen))
+	outputBound := zstd.CompressBound(rawLen)
+	output := make([]byte, len(decompressedSize)+outputBound)
+	copy(output, decompressedSize)
+	compressed, err := zstd.CompressLevel(output[len(decompressedSize):], input, 3)
+	if err != nil {
+		return nil
+	}
+	return output[:len(decompressedSize)+len(compressed)]
+}
+
+func isGoodCompressionRatio(compressed, raw []byte) bool {
+	cl, rl := len(compressed), len(raw)
+	return cl < rl-(rl/8)
+}
+
+func CompressBlock(raw []byte, tp CompressionType) ([]byte, bool) {
+	var compressed []byte
+	switch tp {
+	case CompressionLz4:
+		compressed = lz4Compress(raw)
+	case CompressionSnappy:
+		compressed = snappyCompress(raw)
+	case CompressionZstd:
+		compressed = zstdCompress(raw)
+	case CompressionNone:
+		return raw, false
+	}
+	if !isGoodCompressionRatio(compressed, raw) {
+		return raw, false
+	}
+	return compressed, true
+}

--- a/rocksdb/compression.go
+++ b/rocksdb/compression.go
@@ -1,3 +1,12 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
 package rocksdb
 
 import (

--- a/rocksdb/filter_builder.go
+++ b/rocksdb/filter_builder.go
@@ -1,3 +1,12 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
 package rocksdb
 
 import (

--- a/rocksdb/filter_builder.go
+++ b/rocksdb/filter_builder.go
@@ -1,0 +1,139 @@
+package rocksdb
+
+import (
+	"bytes"
+	"github.com/coocood/badger/y"
+)
+
+type fullFilterBlockBuilder struct {
+	prefixExtractor      SliceTransform
+	bitsBuilder          fullFilterBitsBuilder
+	wholeKeyFiltering    bool
+	lastWholeKeyRecorded bool
+	lastWholeKey         []byte
+	lastPrefixRecorded   bool
+	lastPrefix           []byte
+	numAdded             int
+}
+
+func newFullFilterBlockBuilder(opts *BlockBasedTableOptions) *fullFilterBlockBuilder {
+	return &fullFilterBlockBuilder{
+		prefixExtractor:   opts.PrefixExtractor,
+		wholeKeyFiltering: opts.WholeKeyFiltering,
+		bitsBuilder: fullFilterBitsBuilder{
+			bitsPerKey: opts.BloomBitsPerKey,
+			numProbes:  opts.BloomNumProbes,
+		},
+	}
+}
+
+func (b *fullFilterBlockBuilder) Add(key []byte) {
+	addPrefix := b.prefixExtractor != nil && b.prefixExtractor.InDomain(key)
+	if b.wholeKeyFiltering {
+		if !addPrefix {
+			b.addKey(key)
+		} else {
+			// if both whole_key and prefix are added to bloom then we will have whole
+			// key and prefix addition being interleaved and thus cannot rely on the
+			// bits builder to properly detect the duplicates by comparing with the
+			// last item.
+			if !b.lastWholeKeyRecorded || bytes.Compare(b.lastWholeKey, key) != 0 {
+				b.addKey(key)
+				b.lastWholeKeyRecorded = true
+				b.lastWholeKey = y.SafeCopy(b.lastWholeKey, key)
+			}
+		}
+	}
+	if addPrefix {
+		b.addPrefix(key)
+	}
+}
+
+func (b *fullFilterBlockBuilder) Empty() bool {
+	return b.numAdded == 0
+}
+
+func (b *fullFilterBlockBuilder) addKey(key []byte) {
+	b.bitsBuilder.AddKey(key)
+	b.numAdded++
+}
+
+func (b *fullFilterBlockBuilder) addPrefix(key []byte) {
+	prefix := b.prefixExtractor.Transform(key)
+
+	if b.wholeKeyFiltering {
+		if !b.lastWholeKeyRecorded || bytes.Compare(b.lastPrefix, prefix) != 0 {
+			b.addKey(prefix)
+			b.lastPrefixRecorded = true
+			b.lastPrefix = y.SafeCopy(b.lastPrefix, prefix)
+		}
+		return
+	}
+
+	b.addKey(prefix)
+}
+
+func (b *fullFilterBlockBuilder) Finish() []byte {
+	if b.numAdded != 0 {
+		b.numAdded = 0
+		return b.bitsBuilder.Finish()
+	}
+	return nil
+}
+
+type fullFilterBitsBuilder struct {
+	bitsPerKey  int
+	numProbes   int
+	hashEntries []uint32
+}
+
+func (b *fullFilterBitsBuilder) AddKey(key []byte) {
+	hash := bloomHash(key)
+	if len(b.hashEntries) == 0 || hash != b.hashEntries[len(b.hashEntries)-1] {
+		b.hashEntries = append(b.hashEntries, hash)
+	}
+}
+
+func (b *fullFilterBitsBuilder) Finish() []byte {
+	buf, totalBits, numLines := b.prepareFilterBuffer()
+	if totalBits != 0 && numLines != 0 {
+		for _, h := range b.hashEntries {
+			b.addHash(h, buf, totalBits, numLines)
+		}
+	}
+	buf[totalBits/8] = byte(b.numProbes)
+	rocksEndian.PutUint32(buf[totalBits/8+1:], numLines)
+	return buf
+}
+
+func (b *fullFilterBitsBuilder) prepareFilterBuffer() ([]byte, uint32, uint32) {
+	var numLines, totalBits uint32
+	if len(b.hashEntries) != 0 {
+		numLines, totalBits = b.optimizeBitsForLocality(uint32(len(b.hashEntries) * b.bitsPerKey))
+	}
+
+	sz := totalBits/8 + 5
+	return make([]byte, sz), totalBits, numLines
+}
+
+func (b *fullFilterBitsBuilder) optimizeBitsForLocality(bits uint32) (uint32, uint32) {
+	numLines := (bits + cacheLineSize*8 - 1) / (cacheLineSize * 8)
+	if numLines%2 == 0 {
+		numLines++
+	}
+	return numLines, numLines * (cacheLineSize * 8)
+}
+
+func (b *fullFilterBitsBuilder) addHash(hash uint32, buf []byte, totalBits, numLines uint32) {
+	delta := (hash >> 17) | (hash << 15)
+	base := (hash % numLines) * (cacheLineSize * 8)
+	for i := 0; i < b.numProbes; i++ {
+		bitpos := base + (hash % (cacheLineSize * 8))
+		buf[bitpos/8] |= 1 << (bitpos % 8)
+		hash += delta
+	}
+}
+
+func bloomHash(key []byte) uint32 {
+	return rocksHash(key, 0xbc9f1d34)
+}

--- a/rocksdb/options.go
+++ b/rocksdb/options.go
@@ -1,3 +1,12 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
 package rocksdb
 
 import "golang.org/x/time/rate"

--- a/rocksdb/options.go
+++ b/rocksdb/options.go
@@ -1,0 +1,89 @@
+package rocksdb
+
+import "golang.org/x/time/rate"
+
+type CompressionType uint8
+
+const (
+	CompressionNone   CompressionType = 0x0
+	CompressionSnappy                 = 0x1
+	CompressionLz4                    = 0x4
+	CompressionZstd                   = 0x7
+)
+
+func (tp CompressionType) String() string {
+	switch tp {
+	case CompressionNone:
+		return "NoCompression"
+	case CompressionSnappy:
+		return "Snappy"
+	case CompressionLz4:
+		return "LZ4"
+	case CompressionZstd:
+		return "ZSTD"
+	default:
+		panic("unknown CompressionType")
+	}
+}
+
+type ChecksumType uint8
+
+const (
+	ChecksumNone   ChecksumType = 0x0
+	ChecksumCRC32               = 0x1
+	ChecksumXXHash              = 0x2
+)
+
+type BlockBasedTableOptions struct {
+	BlockSize                 int
+	BlockSizeDeviation        int
+	BlockRestartInterval      int
+	IndexBlockRestartInterval int
+	BlockAlign                bool
+	CompressionType           CompressionType
+	ChecksumType              ChecksumType
+	EnableIndexCompression    bool
+	CreationTime              uint64
+	OldestKeyTime             uint64
+
+	PropsInjectors []PropsInjector
+
+	BloomBitsPerKey   int
+	BloomNumProbes    int
+	WholeKeyFiltering bool
+
+	PrefixExtractorName string
+	PrefixExtractor     SliceTransform
+
+	Comparator   Comparator
+	BufferSize   int
+	BytesPerSync int
+	RateLimiter  *rate.Limiter
+}
+
+func NewDefaultBlockBasedTableOptions(cmp Comparator) *BlockBasedTableOptions {
+	return &BlockBasedTableOptions{
+		BlockSize:                 4 * 1024,
+		BlockSizeDeviation:        10,
+		BlockRestartInterval:      16,
+		IndexBlockRestartInterval: 1,
+		BlockAlign:                false,
+		CompressionType:           CompressionSnappy,
+		ChecksumType:              ChecksumCRC32,
+		EnableIndexCompression:    true,
+		CreationTime:              0,
+		OldestKeyTime:             0,
+
+		BloomBitsPerKey:   10,
+		BloomNumProbes:    6,
+		WholeKeyFiltering: true,
+
+		PrefixExtractorName: "",
+		PrefixExtractor:     nil,
+
+		Comparator:   cmp,
+		BufferSize:   1 * 1024 * 1024,
+		BytesPerSync: 0,
+		RateLimiter:  nil,
+	}
+}

--- a/rocksdb/props_block_builder.go
+++ b/rocksdb/props_block_builder.go
@@ -1,3 +1,12 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
 package rocksdb
 
 import (

--- a/rocksdb/props_block_builder.go
+++ b/rocksdb/props_block_builder.go
@@ -1,0 +1,68 @@
+package rocksdb
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"sort"
+)
+
+const (
+	propColumnFamilyId      = "rocksdb.column.family.id"
+	propCompression         = "rocksdb.compression"
+	propCreationTime        = "rocksdb.creation.time"
+	propDataSize            = "rocksdb.data.size"
+	propFilterPolicy        = "rocksdb.filter.policy"
+	propFilterSize          = "rocksdb.filter.size"
+	propFixedKeyLength      = "rocksdb.fixed.key.length"
+	propFormatVersion       = "rocksdb.format.version"
+	propIndexKeyIsUserKey   = "rocksdb.index.key.is.user.key"
+	propIndexSize           = "rocksdb.index.size"
+	propNumDataBlocks       = "rocksdb.num.data.blocks"
+	propNumEntries          = "rocksdb.num.entries"
+	propOldestKeyTime       = "rocksdb.oldest.key.time"
+	propPrefixExtractorName = "rocksdb.prefix.extractor.name"
+	propRawKeySize          = "rocksdb.raw.key.size"
+	propRawValueSize        = "rocksdb.raw.value.size"
+)
+
+type PropsInjector func(*PropsBlockBuilder)
+
+type PropsBlockBuilder struct {
+	blockBuilder blockBuilder
+	props        []propKV
+}
+
+type propKV struct {
+	key   []byte
+	value []byte
+}
+
+func newPropsBlockBuilder() *PropsBlockBuilder {
+	b := new(PropsBlockBuilder)
+	b.blockBuilder.Init(math.MaxInt32)
+	return b
+}
+
+func (b *PropsBlockBuilder) Add(name string, value []byte) {
+	b.props = append(b.props, propKV{key: []byte(name), value: value})
+}
+
+func (b *PropsBlockBuilder) AddUint64(name string, value uint64) {
+	var buf [binary.MaxVarintLen64]byte
+	b.Add(name, encodeVarint64(buf[:], value))
+}
+
+func (b *PropsBlockBuilder) AddString(name, value string) {
+	b.Add(name, []byte(value))
+}
+
+func (b *PropsBlockBuilder) Finish() []byte {
+	sort.Slice(b.props, func(i, j int) bool {
+		return bytes.Compare(b.props[i].key, b.props[j].key) < 0
+	})
+	for _, p := range b.props {
+		b.blockBuilder.Add(p.key, p.value)
+	}
+	return b.blockBuilder.Finish()
+}

--- a/rocksdb/slice_transform.go
+++ b/rocksdb/slice_transform.go
@@ -1,0 +1,72 @@
+package rocksdb
+
+var (
+	_ SliceTransform = new(FixedPrefixSliceTransform)
+	_ SliceTransform = new(FixedSuffixSliceTransform)
+	_ SliceTransform = new(NoopSliceTransform)
+)
+
+type SliceTransform interface {
+	Transform([]byte) []byte
+	InDomain([]byte) bool
+	InRange([]byte) bool
+}
+
+type FixedPrefixSliceTransform struct {
+	prefixLen int
+}
+
+func NewFixedPrefixSliceTransform(prefixLen int) *FixedPrefixSliceTransform {
+	return &FixedPrefixSliceTransform{prefixLen: prefixLen}
+}
+
+func (st *FixedPrefixSliceTransform) Transform(key []byte) []byte {
+	return key[:st.prefixLen]
+}
+
+func (st *FixedPrefixSliceTransform) InDomain(key []byte) bool {
+	return len(key) >= st.prefixLen
+}
+
+func (st *FixedPrefixSliceTransform) InRange(key []byte) bool {
+	return true
+}
+
+type FixedSuffixSliceTransform struct {
+	suffixLen int
+}
+
+func NewFixedSuffixSliceTransform(suffixLen int) *FixedSuffixSliceTransform {
+	return &FixedSuffixSliceTransform{suffixLen: suffixLen}
+}
+
+func (st *FixedSuffixSliceTransform) Transform(key []byte) []byte {
+	mid := len(key) - st.suffixLen
+	return key[:mid]
+}
+
+func (st *FixedSuffixSliceTransform) InDomain(key []byte) bool {
+	return len(key) >= st.suffixLen
+}
+
+func (st *FixedSuffixSliceTransform) InRange(key []byte) bool {
+	return true
+}
+
+type NoopSliceTransform struct{}
+
+func NewNoopSliceTransform() *NoopSliceTransform {
+	return &NoopSliceTransform{}
+}
+
+func (st *NoopSliceTransform) Transform(key []byte) []byte {
+	return key
+}
+
+func (st *NoopSliceTransform) InDomain(key []byte) bool {
+	return true
+}
+
+func (st *NoopSliceTransform) InRange(key []byte) bool {
+	return true
+}

--- a/rocksdb/slice_transform.go
+++ b/rocksdb/slice_transform.go
@@ -1,3 +1,12 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
 package rocksdb
 
 var (

--- a/rocksdb/sst_file_writer.go
+++ b/rocksdb/sst_file_writer.go
@@ -1,0 +1,74 @@
+package rocksdb
+
+import (
+	"github.com/coocood/badger/y"
+	"github.com/pkg/errors"
+	"os"
+)
+
+var (
+	ErrKeyOrder       = errors.New("Keys must be added in order")
+	ErrNotSupportType = errors.New("Value type is not supported")
+)
+
+const (
+	propExternalSstFileVersion = "rocksdb.external_sst_file.version"
+	propGlobalSeqNo            = "rocksdb.external_sst_file.global_seqno"
+)
+
+type SstFileWriter struct {
+	builder    *BlockBasedTableBuilder
+	lastKey    []byte
+	comparator Comparator
+}
+
+func NewSstFileWriter(f *os.File, opts *BlockBasedTableOptions) *SstFileWriter {
+	w := new(SstFileWriter)
+	opts.PropsInjectors = append(opts.PropsInjectors, func(builder *PropsBlockBuilder) {
+		builder.AddUint64(propExternalSstFileVersion, 2)
+		builder.AddUint64(propGlobalSeqNo, 0)
+	})
+	w.builder = NewBlockBasedTableBuilder(f, opts)
+	w.comparator = opts.Comparator
+	return w
+}
+
+func (w *SstFileWriter) Put(key, value []byte) error {
+	return w.add(key, value, TypeValue)
+}
+
+func (w *SstFileWriter) Merge(key, value []byte) error {
+	return w.add(key, value, TypeMerge)
+}
+
+func (w *SstFileWriter) Delete(key []byte) error {
+	return w.add(key, nil, TypeDeletion)
+}
+
+func (w *SstFileWriter) Finish() error {
+	return w.builder.Finish()
+}
+
+func (w *SstFileWriter) add(key, value []byte, tp ValueType) error {
+	if !tp.IsValue() {
+		return ErrNotSupportType
+	}
+	if w.lastKey != nil {
+		if w.comparator(key, w.lastKey) <= 0 {
+			return ErrKeyOrder
+		}
+	}
+
+	ikey := internalKey{
+		UserKey:        key,
+		SequenceNumber: 0,
+		ValueType:      tp,
+	}
+	if err := w.builder.Add(ikey.Encode(), value); err != nil {
+		return err
+	}
+
+	w.lastKey = y.SafeCopy(w.lastKey, key)
+
+	return nil
+}

--- a/rocksdb/sst_file_writer.go
+++ b/rocksdb/sst_file_writer.go
@@ -1,3 +1,12 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
 package rocksdb
 
 import (

--- a/rocksdb/types.go
+++ b/rocksdb/types.go
@@ -1,3 +1,12 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
 package rocksdb
 
 import "encoding/binary"

--- a/rocksdb/types.go
+++ b/rocksdb/types.go
@@ -1,0 +1,113 @@
+package rocksdb
+
+import "encoding/binary"
+
+type ValueType uint8
+
+const (
+	TypeDeletion ValueType = iota
+	TypeValue
+	TypeMerge
+)
+
+func (vt ValueType) IsValue() bool {
+	return vt <= TypeMerge
+}
+
+type Comparator func(key1 []byte, key2 []byte) int
+
+// CompareInternalKey compares two keys order by:
+//    increasing user key (according to user-supplied comparator)
+//    decreasing sequence number
+//    decreasing type (though sequence# should be enough to disambiguate)
+func (c Comparator) CompareInternalKey(key1, key2 []byte) int {
+	k1 := key1[:len(key1)-8]
+	k2 := key2[:len(key2)-8]
+	cmp := c(k1, k2)
+	if cmp == 0 {
+		num1 := rocksEndian.Uint64(key1[len(key1)-8:])
+		num2 := rocksEndian.Uint64(key2[len(key2)-8:])
+		if num1 > num2 {
+			cmp = -1
+		} else if num1 < num2 {
+			cmp = +1
+		}
+	}
+	return cmp
+}
+
+type TableProperties struct {
+	DataSize            uint64
+	IndexSize           uint64
+	FilterSize          uint64
+	RawKeySize          uint64
+	RawValueSize        uint64
+	NumDataBlocks       uint64
+	NumEntries          uint64
+	ColumnFamilyID      uint64
+	ColumnFamilyName    string
+	CompressionName     string
+	FilterPolicyName    string
+	CreationTime        uint64
+	OldestKeyTime       uint64
+	PrefixExtractorName string
+}
+
+type blockHandle struct {
+	Offset uint64
+	Size   uint64
+}
+
+func (h blockHandle) Encode() []byte {
+	result := make([]byte, 2*binary.MaxVarintLen64)
+	n := h.EncodeTo(result)
+	return result[:n]
+}
+
+func (h blockHandle) EncodeTo(buf []byte) int {
+	var b [binary.MaxVarintLen64]byte
+	cursor := 0
+	off := encodeVarint64(buf[:], h.Offset)
+	copy(buf[cursor:], off)
+	cursor += len(off)
+	sz := encodeVarint64(b[:], h.Size)
+	copy(buf[cursor:], sz)
+	return cursor + len(sz)
+}
+
+func (h *blockHandle) Decode(buf []byte) int {
+	off, n1 := binary.Uvarint(buf)
+	sz, n2 := binary.Uvarint(buf[n1:])
+	h.Offset = off
+	h.Size = sz
+	return n1 + n2
+}
+
+type internalKey struct {
+	UserKey        []byte
+	SequenceNumber uint64
+	ValueType      ValueType
+}
+
+func (ikey *internalKey) Encode() []byte {
+	buf := make([]byte, len(ikey.UserKey)+8)
+	copy(buf, ikey.UserKey)
+	rocksEndian.PutUint64(buf[len(ikey.UserKey):], ikey.packSeqAndType())
+	return buf
+}
+
+func (ikey *internalKey) Decode(encoded []byte) {
+	ikey.UserKey = ikey.UserKey[:0]
+	userKeyLen := len(encoded) - 8
+	ikey.UserKey = append(ikey.UserKey, encoded[0:userKeyLen]...)
+	ikey.unpackSeqAndType(rocksEndian.Uint64(encoded[userKeyLen:]))
+}
+
+func (ikey *internalKey) packSeqAndType() uint64 {
+	return ikey.SequenceNumber<<8 | uint64(ikey.ValueType)
+}
+
+func (ikey *internalKey) unpackSeqAndType(pack uint64) {
+	ikey.ValueType = ValueType(pack & 0xff)
+	ikey.SequenceNumber = pack >> 8
+}

--- a/rocksdb/utils.go
+++ b/rocksdb/utils.go
@@ -1,0 +1,119 @@
+package rocksdb
+
+import (
+	"encoding/binary"
+	"hash"
+	"hash/crc32"
+)
+
+var (
+	rocksEndian   = binary.LittleEndian
+	rocksCrcTable = crc32.MakeTable(crc32.Castagnoli)
+)
+
+const cacheLineSize = 64
+
+func differenceOffset(lhs, rhs []byte) int {
+	l := len(lhs)
+	if len(rhs) < len(lhs) {
+		l = len(rhs)
+	}
+
+	off := 0
+	for ; off < l; off++ {
+		if lhs[off] != rhs[off] {
+			break
+		}
+	}
+	return off
+}
+
+func encodeVarint32(buf []byte, v uint32) []byte {
+	_ = buf[4]
+	const B = 128
+	if v < (1 << 7) {
+		buf[0] = byte(v)
+		return buf[:1]
+	} else if v < (1 << 14) {
+		buf[0] = byte(v | B)
+		buf[1] = byte(v >> 7)
+		return buf[:2]
+	} else if v < (1 << 21) {
+		buf[0] = byte(v | B)
+		buf[1] = byte((v >> 7) | B)
+		buf[2] = byte(v >> 14)
+		return buf[:3]
+	} else if v < (1 << 28) {
+		buf[0] = byte(v | B)
+		buf[1] = byte((v >> 7) | B)
+		buf[2] = byte((v >> 14) | B)
+		buf[3] = byte(v >> 21)
+		return buf[:4]
+	} else {
+		buf[0] = byte(v | B)
+		buf[1] = byte((v >> 7) | B)
+		buf[2] = byte((v >> 14) | B)
+		buf[3] = byte((v >> 21) | B)
+		buf[4] = byte(v >> 28)
+		return buf[:5]
+	}
+}
+
+func encodeVarint64(buf []byte, v uint64) []byte {
+	n := binary.PutUvarint(buf, v)
+	return buf[:n]
+}
+
+func appendVarint32(buf []byte, v uint32) []byte {
+	var e [5]byte
+	result := encodeVarint32(e[:], v)
+	return append(buf, result...)
+}
+
+const crc32MaskDelta = 0xa282ead8
+
+func maskCrc32(sum uint32) uint32 {
+	return ((sum >> 15) | (sum << 17)) + crc32MaskDelta
+}
+
+func unmaskCrc32(sum uint32) uint32 {
+	rot := sum - crc32MaskDelta
+	return (rot >> 17) | (rot << 15)
+}
+
+func newCrc32() hash.Hash32 {
+	return crc32.New(rocksCrcTable)
+}
+
+func extractUserKey(key []byte) []byte {
+	return key[:len(key)-8]
+}
+
+func rocksHash(data []byte, seed uint32) uint32 {
+	const m = 0xc6a4a793
+	const r = 24
+	h := seed ^ uint32(len(data)*m)
+
+	pos := 0
+	for ; pos+4 < len(data); pos += 4 {
+		w := rocksEndian.Uint32(data[pos : pos+4])
+		h += w
+		h *= m
+		h ^= h >> 16
+	}
+
+	// Pick up remaining bytes
+	remain := len(data) - pos
+	if remain == 3 {
+		h += uint32(int8(data[2])) << 16
+	}
+	if remain >= 2 {
+		h += uint32(int8(data[1])) << 8
+	}
+	if remain >= 1 {
+		h += uint32(int8(data[0]))
+		h *= m
+		h ^= h >> r
+	}
+	return h
+}

--- a/rocksdb/utils.go
+++ b/rocksdb/utils.go
@@ -1,3 +1,12 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
 package rocksdb
 
 import (


### PR DESCRIPTION
I have checked some sst files, which generated by this SstFileWriter with different table size and compression algorithm, using RocksDB's sst check tools and `IngestExternalFiles`.   

This writer simplified many options in RocksDB, which doesn't use by TiKV. We can add them back if need.

I can port some unit tests later.

The first step of #107 😁