### PR TITLE
refactor writeDBWorker and server batch to use channel instead of mutex.

### DIFF
--- a/tikv/mvcc.go
+++ b/tikv/mvcc.go
@@ -47,7 +47,7 @@ func NewMVCCStore(dbs []*badger.DB, dataDir string, safePoint *SafePoint) *MVCCS
 		lockStore:     ls,
 		rollbackStore: rollbackStore,
 		writeLockWorker: &writeLockWorker{
-			wakeUp:  make(chan struct{}, 1),
+			batchCh: make(chan *writeLockBatch, batchChanSize),
 			closeCh: closeCh,
 		},
 		closeCh:   closeCh,
@@ -56,7 +56,7 @@ func NewMVCCStore(dbs []*badger.DB, dataDir string, safePoint *SafePoint) *MVCCS
 	workers := make([]*writeDBWorker, 8)
 	for i := 0; i < 8; i++ {
 		workers[i] = &writeDBWorker{
-			wakeUp:  make(chan struct{}, 1),
+			batchCh: make(chan *writeDBBatch, batchChanSize),
 			closeCh: closeCh,
 			store:   store,
 			idx:     i,

--- a/tikv/write.go
+++ b/tikv/write.go
@@ -95,14 +95,7 @@ func (store *MVCCStore) writeDB(batch *writeDBBatch, dbIdx int) error {
 		return nil
 	}
 	batch.wg.Add(1)
-	w := store.writeDBWorkers[dbIdx]
-	w.mu.Lock()
-	w.mu.batches = append(w.mu.batches, batch)
-	w.mu.Unlock()
-	select {
-	case w.wakeUp <- struct{}{}:
-	default:
-	}
+	store.writeDBWorkers[dbIdx].batchCh <- batch
 	batch.wg.Wait()
 	return batch.err
 }
@@ -112,24 +105,13 @@ func (store *MVCCStore) writeLocks(batch *writeLockBatch) error {
 		return nil
 	}
 	batch.wg.Add(1)
-	w := store.writeLockWorker
-	w.mu.Lock()
-	w.mu.batches = append(w.mu.batches, batch)
-	w.mu.Unlock()
-	select {
-	case w.wakeUp <- struct{}{}:
-	default:
-	}
+	store.writeLockWorker.batchCh <- batch
 	batch.wg.Wait()
 	return batch.err
 }
 
 type writeDBWorker struct {
-	mu struct {
-		sync.Mutex
-		batches []*writeDBBatch
-	}
-	wakeUp  chan struct{}
+	batchCh chan *writeDBBatch
 	closeCh <-chan struct{}
 	store   *MVCCStore
 	idx     int
@@ -137,16 +119,11 @@ type writeDBWorker struct {
 
 func (w *writeDBWorker) run() {
 	defer w.store.wg.Done()
+	var batches []*writeDBBatch
 	for {
-		select {
-		case <-w.store.closeCh:
-			return
-		case <-w.wakeUp:
-		}
-		batches := make([]*writeDBBatch, 0, 128)
-		w.mu.Lock()
-		batches, w.mu.batches = w.mu.batches, batches
-		w.mu.Unlock()
+
+
+
 		if len(batches) > 0 {
 			w.updateBatchGroup(batches)
 		}
@@ -177,11 +154,7 @@ func (w *writeDBWorker) updateBatchGroup(batchGroup []*writeDBBatch) {
 }
 
 type writeLockWorker struct {
-	mu struct {
-		sync.Mutex
-		batches []*writeLockBatch
-	}
-	wakeUp  chan struct{}
+	batchCh chan *writeLockBatch
 	closeCh <-chan struct{}
 	store   *MVCCStore
 }
@@ -192,15 +165,17 @@ func (w *writeLockWorker) run() {
 	ls := w.store.lockStore
 	var batches []*writeLockBatch
 	for {
+		batches = batches[:0]
 		select {
 		case <-w.store.closeCh:
 			return
-		case <-w.wakeUp:
+		case batch := <-w.batchCh:
+			batches = append(batches, batch)
 		}
-		batches = batches[:0]
-		w.mu.Lock()
-		batches, w.mu.batches = w.mu.batches, batches
-		w.mu.Unlock()
+		chLen := len(w.batchCh)
+		for i := 0; i < chLen; i++ {
+			batches = append(batches, <-w.batchCh)
+		}
 		var delCnt, insertCnt int
 		for _, batch := range batches {
 			for _, entry := range batch.entries {


### PR DESCRIPTION
I recently did a microbenchmark for the two approaches of batching, the difference is very small.
Changing mutex to channel can simplify the code, easier to understand.