### PR TITLE
remove etcd/raft dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,11 +12,12 @@ require (
 	github.com/pierrec/lz4 v2.0.5+incompatible
 	github.com/pingcap/check v0.0.0-20181213055612-5c2b07721bdb
 	github.com/pingcap/errors v0.11.0
-	github.com/pingcap/kvproto v0.0.0-20190215154024-7f2fc73ef562
+	github.com/pingcap/kvproto v0.0.0-20190227013052-e71ca0165a5f
 	github.com/pingcap/parser v0.0.0-20181218071912-deacf026787e
 	github.com/pingcap/tidb v0.0.0-20181130082510-08f0168a6cae
 	github.com/pingcap/tipb v0.0.0-20181012112600-11e33c750323
 	github.com/stretchr/testify v1.2.2
+	github.com/zhangjinpeng1987/raft v0.0.0-20190228074655-af4f3152c5f3
 	go.etcd.io/etcd v3.3.12+incompatible
 	golang.org/x/net v0.0.0-20181029044818-c44066c5c816
 	golang.org/x/sys v0.0.0-20181025063200-d989b31c8746 // indirect

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/pingcap/tidb v0.0.0-20181130082510-08f0168a6cae
 	github.com/pingcap/tipb v0.0.0-20181012112600-11e33c750323
 	github.com/stretchr/testify v1.2.2
-	github.com/zhangjinpeng1987/raft v0.0.0-20190228074655-af4f3152c5f3
+	github.com/zhangjinpeng1987/raft v0.0.0-20190228081702-27ed295a81b4
 	go.etcd.io/etcd v3.3.12+incompatible
 	golang.org/x/net v0.0.0-20181029044818-c44066c5c816
 	golang.org/x/sys v0.0.0-20181025063200-d989b31c8746 // indirect

--- a/go.sum
+++ b/go.sum
@@ -180,6 +180,8 @@ github.com/zhangjinpeng1987/etcd v0.0.0-20190226085253-137eac022b64 h1:szZaDgp51
 github.com/zhangjinpeng1987/etcd v0.0.0-20190226085253-137eac022b64/go.mod h1:RutfZdQAP913VY0GI8/Mjwf50+IZ7Mpg2zt3SDs17/g=
 github.com/zhangjinpeng1987/raft v0.0.0-20190228074655-af4f3152c5f3 h1:r25p4ej8yWgdPIXPjrwmYrPu4ZZr5yDr7khmnpP8khs=
 github.com/zhangjinpeng1987/raft v0.0.0-20190228074655-af4f3152c5f3/go.mod h1:1KDQ09J8MRHEtHze4at7BJZDW/doUAgkJ8w9KjEUhSo=
+github.com/zhangjinpeng1987/raft v0.0.0-20190228081702-27ed295a81b4 h1:jIsypsrxpFN5wzqD9XKYiVL8OW6BnWH3qRP2p5K1KyU=
+github.com/zhangjinpeng1987/raft v0.0.0-20190228081702-27ed295a81b4/go.mod h1:1KDQ09J8MRHEtHze4at7BJZDW/doUAgkJ8w9KjEUhSo=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.uber.org/atomic v1.3.2 h1:2Oa65PReHzfn29GpvgsYwloV9AVFHPDk8tYxt2c2tr4=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e/go.mod h1:O17Xtb
 github.com/pingcap/kvproto v0.0.0-20181105061835-1b5d69cd1d26/go.mod h1:0gwbe1F2iBIjuQ9AH0DbQhL+Dpr5GofU8fgYyXk+ykk=
 github.com/pingcap/kvproto v0.0.0-20190215154024-7f2fc73ef562 h1:32oF1/8lVnBR2JVcCAnKPQATTOX0+ckRDFpjQk4Ngno=
 github.com/pingcap/kvproto v0.0.0-20190215154024-7f2fc73ef562/go.mod h1:QMdbTAXCHzzygQzqcG9uVUgU2fKeSN1GmfMiykdSzzY=
+github.com/pingcap/kvproto v0.0.0-20190227013052-e71ca0165a5f h1:4hYEuFIwCBrrf0OLGX7lbVmhYzOiNCFUf6ldjo21h7Q=
+github.com/pingcap/kvproto v0.0.0-20190227013052-e71ca0165a5f/go.mod h1:QMdbTAXCHzzygQzqcG9uVUgU2fKeSN1GmfMiykdSzzY=
 github.com/pingcap/parser v0.0.0-20181218071912-deacf026787e h1:jKibIs55HR7OMo62uhjA6Bfx3GK+rbHK4Gfd4/8aTzk=
 github.com/pingcap/parser v0.0.0-20181218071912-deacf026787e/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v2.1.0-rc.4+incompatible h1:/buwGk04aHO5odk/+O8ZOXGs4qkUjYTJ2UpCJXna8NE=
@@ -174,7 +176,10 @@ github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/zhangjinpeng1987/etcd v0.0.0-20190225050241-2507590cb313 h1:p2wZKVncqadnd55GGOFAMmOJHEDrfTbW0lujgMUJcvQ=
 github.com/zhangjinpeng1987/etcd v0.0.0-20190225050241-2507590cb313/go.mod h1:RutfZdQAP913VY0GI8/Mjwf50+IZ7Mpg2zt3SDs17/g=
+github.com/zhangjinpeng1987/etcd v0.0.0-20190226085253-137eac022b64 h1:szZaDgp51C3/4QgF2cbex4EL5/yFFyASnFYParRH6QA=
 github.com/zhangjinpeng1987/etcd v0.0.0-20190226085253-137eac022b64/go.mod h1:RutfZdQAP913VY0GI8/Mjwf50+IZ7Mpg2zt3SDs17/g=
+github.com/zhangjinpeng1987/raft v0.0.0-20190228074655-af4f3152c5f3 h1:r25p4ej8yWgdPIXPjrwmYrPu4ZZr5yDr7khmnpP8khs=
+github.com/zhangjinpeng1987/raft v0.0.0-20190228074655-af4f3152c5f3/go.mod h1:1KDQ09J8MRHEtHze4at7BJZDW/doUAgkJ8w9KjEUhSo=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.uber.org/atomic v1.3.2 h1:2Oa65PReHzfn29GpvgsYwloV9AVFHPDk8tYxt2c2tr4=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/tikv/raftstore/entry.go
+++ b/tikv/raftstore/entry.go
@@ -1,10 +1,5 @@
 package raftstore
 
-import (
-	"go.etcd.io/etcd/raft/raftpb"
-	"github.com/pingcap/kvproto/pkg/eraftpb"
-)
-
 const (
 	entryCtxSynclog      entryCtx = 1
 	entryCtxSplit        entryCtx = 1 << 1
@@ -36,30 +31,4 @@ func (pc *entryCtx) SetPrepareMerge() {
 
 func (pc entryCtx) IsPrepareMerge() bool {
 	return pc&entryCtxPrepareMerge > 0
-}
-
-// The raftpb.Entry is the type used in etcd/raft, but tikv use eraftpb.Entry which have extra field Context.
-// We need to implement to etcd/raft interface, so we have to do the conversion.
-func convertEEntryToEntry(eEntry *eraftpb.Entry) raftpb.Entry {
-	entry := raftpb.Entry{}
-	entry.Type = raftpb.EntryType(eEntry.EntryType)
-	entry.Term = eEntry.Term
-	entry.Index = eEntry.Index
-	var eCtx entryCtx
-	if len(eEntry.Context) > 0 {
-		eCtx = entryCtx(eEntry.Context[0])
-	}
-	entry.Data = append(eEntry.Data, byte(eCtx))
-	return entry
-}
-
-func convertEntryToEEntry(entry raftpb.Entry) *eraftpb.Entry {
-	eEntry := new(eraftpb.Entry)
-	eEntry.EntryType = eraftpb.EntryType(entry.Type)
-	eEntry.Term = entry.Term
-	eEntry.Index = entry.Index
-	lastByteIdx := len(entry.Data) - 1
-	eEntry.Context = entry.Data[lastByteIdx:]
-	eEntry.Data = entry.Data[:lastByteIdx]
-	return eEntry
 }

--- a/tikv/raftstore/msg.go
+++ b/tikv/raftstore/msg.go
@@ -3,7 +3,7 @@ package raftstore
 import (
 	"time"
 
-	"github.com/zhangjinpeng1987/raft/raft"
+	"github.com/zhangjinpeng1987/raft"
 	"github.com/ngaut/unistore/rocksdb"
 	"github.com/pingcap/kvproto/pkg/import_sstpb"
 	"github.com/pingcap/kvproto/pkg/metapb"

--- a/tikv/raftstore/msg.go
+++ b/tikv/raftstore/msg.go
@@ -3,7 +3,7 @@ package raftstore
 import (
 	"time"
 
-	"go.etcd.io/etcd/raft"
+	"github.com/zhangjinpeng1987/raft/raft"
 	"github.com/ngaut/unistore/rocksdb"
 	"github.com/pingcap/kvproto/pkg/import_sstpb"
 	"github.com/pingcap/kvproto/pkg/metapb"

--- a/tikv/raftstore/peer_storage.go
+++ b/tikv/raftstore/peer_storage.go
@@ -15,7 +15,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/eraftpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	rspb "github.com/pingcap/kvproto/pkg/raft_serverpb"
-	"github.com/zhangjinpeng1987/raft/raft"
+	"github.com/zhangjinpeng1987/raft"
 )
 
 type JobStatus int64

--- a/tikv/raftstore/peer_storage.go
+++ b/tikv/raftstore/peer_storage.go
@@ -15,8 +15,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/eraftpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	rspb "github.com/pingcap/kvproto/pkg/raft_serverpb"
-	"go.etcd.io/etcd/raft"
-	"go.etcd.io/etcd/raft/raftpb"
+	"github.com/zhangjinpeng1987/raft/raft"
 )
 
 type JobStatus int64
@@ -74,14 +73,14 @@ func CompactRaftLog(tag string, state *rspb.RaftApplyState, compactIndex, compac
 }
 
 type EntryCache struct {
-	cache []raftpb.Entry
+	cache []eraftpb.Entry
 }
 
-func (ec *EntryCache) front() raftpb.Entry {
+func (ec *EntryCache) front() eraftpb.Entry {
 	return ec.cache[0]
 }
 
-func (ec *EntryCache) back() raftpb.Entry {
+func (ec *EntryCache) back() eraftpb.Entry {
 	return ec.cache[len(ec.cache)-1]
 }
 
@@ -89,7 +88,7 @@ func (ec *EntryCache) length() int {
 	return len(ec.cache)
 }
 
-func (ec *EntryCache) fetchEntriesTo(begin, end, maxSize uint64, fetchSize *uint64, ents []raftpb.Entry) []raftpb.Entry {
+func (ec *EntryCache) fetchEntriesTo(begin, end, maxSize uint64, fetchSize *uint64, ents []eraftpb.Entry) []eraftpb.Entry {
 	if begin >= end {
 		return nil
 	}
@@ -114,7 +113,7 @@ func (ec *EntryCache) fetchEntriesTo(begin, end, maxSize uint64, fetchSize *uint
 	return ents
 }
 
-func (ec *EntryCache) append(tag string, entries []raftpb.Entry) {
+func (ec *EntryCache) append(tag string, entries []eraftpb.Entry) {
 	if len(entries) == 0 {
 		return
 	}
@@ -353,7 +352,7 @@ func initLastTerm(raftEngine *badger.DB, region *metapb.Region,
 		y.Assert(lastIdx > RaftInitLogIndex)
 	}
 	lastLogKey := RaftLogKey(region.Id, lastIdx)
-	e := new(raftpb.Entry)
+	e := new(eraftpb.Entry)
 	err := getMsg(raftEngine, lastLogKey, e)
 	if err != nil {
 		return 0, errors.Errorf("[region %s] entry at %d doesn't exist, may lost data.", region, lastIdx)
@@ -361,22 +360,22 @@ func initLastTerm(raftEngine *badger.DB, region *metapb.Region,
 	return e.Term, nil
 }
 
-func (ps *PeerStorage) InitialState() (raftpb.HardState, raftpb.ConfState, error) {
+func (ps *PeerStorage) InitialState() (eraftpb.HardState, eraftpb.ConfState, error) {
 	hardState := ps.raftState.HardState
 	if hardState.Commit == 0 && hardState.Term == 0 && hardState.Vote == 0 {
 		y.AssertTruef(!ps.isInitialized(),
 			"peer for region %s is initialized but local state %s has empty hard state",
 			ps.region, ps.raftState)
-		return raftpb.HardState{}, raftpb.ConfState{}, nil
+		return eraftpb.HardState{}, eraftpb.ConfState{}, nil
 	}
-	return raftpb.HardState{
+	return eraftpb.HardState{
 		Term:   hardState.Term,
 		Vote:   hardState.Vote,
 		Commit: hardState.Commit,
 	}, confStateFromRegion(ps.region), nil
 }
 
-func confStateFromRegion(region *metapb.Region) (confState raftpb.ConfState) {
+func confStateFromRegion(region *metapb.Region) (confState eraftpb.ConfState) {
 	for _, p := range region.Peers {
 		if p.IsLearner {
 			confState.Learners = append(confState.Learners, p.GetId())
@@ -399,12 +398,12 @@ func (ps *PeerStorage) IsApplyingSnapshot() bool {
 	return ps.snapState.StateType == SnapState_Applying
 }
 
-func (ps *PeerStorage) Entries(low, high, maxSize uint64) ([]raftpb.Entry, error) {
+func (ps *PeerStorage) Entries(low, high, maxSize uint64) ([]eraftpb.Entry, error) {
 	err := ps.checkRange(low, high)
 	if err != nil {
 		return nil, err
 	}
-	ents := make([]raftpb.Entry, 0, high-low)
+	ents := make([]eraftpb.Entry, 0, high-low)
 	if low == high {
 		return ents, nil
 	}
@@ -492,14 +491,14 @@ func firstIndex(applyState *rspb.RaftApplyState) uint64 {
 	return applyState.TruncatedState.GetIndex() + 1
 }
 
-func (ps *PeerStorage) Snapshot() (raftpb.Snapshot, error) {
-	return raftpb.Snapshot{}, raft.ErrSnapshotTemporarilyUnavailable
+func (ps *PeerStorage) Snapshot() (eraftpb.Snapshot, error) {
+	return eraftpb.Snapshot{}, raft.ErrSnapshotTemporarilyUnavailable
 }
 
 // Append the given entries to the raft log using previous last index or self.last_index.
 // Return the new last index for later update. After we commit in engine, we can set last_index
 // to the return one.
-func (ps *PeerStorage) Append(invokeCtx *InvokeContext, entries []raftpb.Entry, readyCtx HandleRaftReadyContext) error {
+func (ps *PeerStorage) Append(invokeCtx *InvokeContext, entries []eraftpb.Entry, readyCtx HandleRaftReadyContext) error {
 	log.Debugf("%s append %d entries", ps.Tag, len(entries))
 	prevLastIndex := invokeCtx.RaftState.GetLastIndex()
 	if len(entries) == 0 {
@@ -565,11 +564,11 @@ func (ps *PeerStorage) clearExtraData(newRegion *metapb.Region) {
 	}
 }
 
-func getSyncLogFromEntry(entry raftpb.Entry) bool {
+func getSyncLogFromEntry(entry eraftpb.Entry) bool {
 	return entryCtx(entry.Data[len(entry.Data)-1]).IsSyncLog()
 }
 
-func fetchEntriesTo(engine *badger.DB, regionID, low, high, maxSize uint64, buf []raftpb.Entry) ([]raftpb.Entry, uint64, error) {
+func fetchEntriesTo(engine *badger.DB, regionID, low, high, maxSize uint64, buf []eraftpb.Entry) ([]eraftpb.Entry, uint64, error) {
 	var totalSize uint64
 	nextIndex := low
 	exceededMaxSize := false
@@ -590,7 +589,7 @@ func fetchEntriesTo(engine *badger.DB, regionID, low, high, maxSize uint64, buf 
 			if err != nil {
 				return nil, 0, err
 			}
-			var entry raftpb.Entry
+			var entry eraftpb.Entry
 			err = entry.Unmarshal(val)
 			if err != nil {
 				return nil, 0, err
@@ -624,7 +623,7 @@ func fetchEntriesTo(engine *badger.DB, regionID, low, high, maxSize uint64, buf 
 		if err != nil {
 			return nil, 0, err
 		}
-		var entry raftpb.Entry
+		var entry eraftpb.Entry
 		err = entry.Unmarshal(val)
 		if err != nil {
 			return nil, 0, err
@@ -701,7 +700,7 @@ func WritePeerState(kvWB *WriteBatch, region *metapb.Region, state rspb.PeerStat
 }
 
 // Apply the peer with given snapshot.
-func (ps *PeerStorage) ApplySnapshot(ctx *InvokeContext, snap *raftpb.Snapshot, kvWB *WriteBatch, raftWB *WriteBatch) error {
+func (ps *PeerStorage) ApplySnapshot(ctx *InvokeContext, snap *eraftpb.Snapshot, kvWB *WriteBatch, raftWB *WriteBatch) error {
 	log.Infof("%v begin to apply snapshot", ps.Tag)
 
 	snapData := new(rspb.RaftSnapshotData)
@@ -750,7 +749,7 @@ func (ps *PeerStorage) ApplySnapshot(ctx *InvokeContext, snap *raftpb.Snapshot, 
 func (ps *PeerStorage) HandleRaftReady(readyCtx HandleRaftReadyContext, ready *raft.Ready) (*InvokeContext, error) {
 	ctx := NewInvokeContext(ps)
 	var snapshotIdx uint64 = 0
-	if !raft.IsEmptySnap(ready.Snapshot) {
+	if !raft.IsEmptySnap(&ready.Snapshot) {
 		if err := ps.ApplySnapshot(ctx, &ready.Snapshot, readyCtx.KVWB(), readyCtx.RaftWB()); err != nil {
 			return nil, err
 		}

--- a/tikv/raftstore/peer_storage_test.go
+++ b/tikv/raftstore/peer_storage_test.go
@@ -6,14 +6,14 @@ import (
 	"testing"
 
 	"github.com/coocood/badger"
-	"go.etcd.io/etcd/raft"
-	"go.etcd.io/etcd/raft/raftpb"
+	"github.com/zhangjinpeng1987/raft/raft"
+	"github.com/pingcap/kvproto/pkg/eraftpb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPeerStorageTerm(t *testing.T) {
-	ents := []raftpb.Entry{
+	ents := []eraftpb.Entry{
 		newTestEntry(3, 3), newTestEntry(4, 4), newTestEntry(5, 5),
 	}
 	tests := []struct {
@@ -38,7 +38,7 @@ func TestPeerStorageTerm(t *testing.T) {
 	}
 }
 
-func appendEnts(t *testing.T, peerStore *PeerStorage, ents []raftpb.Entry) {
+func appendEnts(t *testing.T, peerStore *PeerStorage, ents []eraftpb.Entry) {
 	ctx := NewInvokeContext(peerStore)
 	readyCtx := new(readyContext)
 	require.Nil(t, peerStore.Append(ctx, ents, readyCtx))
@@ -47,11 +47,11 @@ func appendEnts(t *testing.T, peerStore *PeerStorage, ents []raftpb.Entry) {
 	peerStore.raftState = &ctx.RaftState
 }
 
-func validateCache(t *testing.T, peerStore *PeerStorage, expEnts []raftpb.Entry) {
+func validateCache(t *testing.T, peerStore *PeerStorage, expEnts []eraftpb.Entry) {
 	assert.Equal(t, peerStore.cache.cache, expEnts)
 	for _, e := range expEnts {
 		key := RaftLogKey(peerStore.region.Id, e.Index)
-		e2 := new(raftpb.Entry)
+		e2 := new(eraftpb.Entry)
 		assert.Nil(t, getMsg(peerStore.Engines.raft, key, e2))
 		assert.Equal(t, *e2, e)
 	}
@@ -104,12 +104,12 @@ func getMetaKeyCount(t *testing.T, peerStore *PeerStorage) int {
 }
 
 func TestPeerStorageClearMeta(t *testing.T) {
-	peerStore := newTestPeerStorageFromEnts(t, []raftpb.Entry{
+	peerStore := newTestPeerStorageFromEnts(t, []eraftpb.Entry{
 		newTestEntry(3, 3),
 		newTestEntry(4, 4),
 	})
 	defer cleanUpTestData(peerStore)
-	appendEnts(t, peerStore, []raftpb.Entry{
+	appendEnts(t, peerStore, []eraftpb.Entry{
 		newTestEntry(5, 5),
 		newTestEntry(6, 6),
 	})
@@ -123,7 +123,7 @@ func TestPeerStorageClearMeta(t *testing.T) {
 }
 
 func TestPeerStorageEntries(t *testing.T) {
-	ents := []raftpb.Entry{
+	ents := []eraftpb.Entry{
 		newTestEntry(3, 3),
 		newTestEntry(4, 4),
 		newTestEntry(5, 5),
@@ -133,36 +133,36 @@ func TestPeerStorageEntries(t *testing.T) {
 		low     uint64
 		high    uint64
 		maxSize uint64
-		entries []raftpb.Entry
+		entries []eraftpb.Entry
 		err     error
 	}{
 		{2, 6, math.MaxUint64, nil, raft.ErrCompacted},
 		{3, 4, math.MaxUint64, nil, raft.ErrCompacted},
-		{4, 5, math.MaxUint64, []raftpb.Entry{
+		{4, 5, math.MaxUint64, []eraftpb.Entry{
 			newTestEntry(4, 4),
 		}, nil},
-		{4, 6, math.MaxUint64, []raftpb.Entry{
+		{4, 6, math.MaxUint64, []eraftpb.Entry{
 			newTestEntry(4, 4),
 			newTestEntry(5, 5),
 		}, nil},
 		// even if maxsize is zero, the first entry should be returned
-		{4, 7, 0, []raftpb.Entry{
+		{4, 7, 0, []eraftpb.Entry{
 			newTestEntry(4, 4),
 		}, nil},
 		// limit to 2
-		{4, 7, uint64(ents[1].Size() + ents[2].Size()), []raftpb.Entry{
+		{4, 7, uint64(ents[1].Size() + ents[2].Size()), []eraftpb.Entry{
 			newTestEntry(4, 4),
 			newTestEntry(5, 5),
 		}, nil},
-		{4, 7, uint64(ents[1].Size() + ents[2].Size() + ents[3].Size()/2), []raftpb.Entry{
+		{4, 7, uint64(ents[1].Size() + ents[2].Size() + ents[3].Size()/2), []eraftpb.Entry{
 			newTestEntry(4, 4),
 			newTestEntry(5, 5),
 		}, nil},
-		{4, 7, uint64(ents[1].Size() + ents[2].Size() + ents[3].Size() - 1), []raftpb.Entry{
+		{4, 7, uint64(ents[1].Size() + ents[2].Size() + ents[3].Size() - 1), []eraftpb.Entry{
 			newTestEntry(4, 4),
 			newTestEntry(5, 5),
 		}, nil},
-		{4, 7, uint64(ents[1].Size() + ents[2].Size() + ents[3].Size()), []raftpb.Entry{
+		{4, 7, uint64(ents[1].Size() + ents[2].Size() + ents[3].Size()), []eraftpb.Entry{
 			newTestEntry(4, 4),
 			newTestEntry(5, 5),
 			newTestEntry(6, 6),
@@ -182,7 +182,7 @@ func TestPeerStorageEntries(t *testing.T) {
 }
 
 func TestPeerStorageCompact(t *testing.T) {
-	ents := []raftpb.Entry{
+	ents := []eraftpb.Entry{
 		newTestEntry(3, 3), newTestEntry(4, 4), newTestEntry(5, 5)}
 	tests := []struct {
 		idx uint64
@@ -213,40 +213,40 @@ func TestPeerStorageCompact(t *testing.T) {
 }
 
 func TestPeerStorageAppend(t *testing.T) {
-	ents := []raftpb.Entry{
+	ents := []eraftpb.Entry{
 		newTestEntry(3, 3), newTestEntry(4, 4), newTestEntry(5, 5)}
 	tests := []struct {
-		appends []raftpb.Entry
-		results []raftpb.Entry
+		appends []eraftpb.Entry
+		results []eraftpb.Entry
 	}{
 		{
-			[]raftpb.Entry{newTestEntry(3, 3), newTestEntry(4, 4), newTestEntry(5, 5)},
-			[]raftpb.Entry{newTestEntry(4, 4), newTestEntry(5, 5)},
+			[]eraftpb.Entry{newTestEntry(3, 3), newTestEntry(4, 4), newTestEntry(5, 5)},
+			[]eraftpb.Entry{newTestEntry(4, 4), newTestEntry(5, 5)},
 		},
 		{
-			[]raftpb.Entry{newTestEntry(3, 3), newTestEntry(4, 6), newTestEntry(5, 6)},
-			[]raftpb.Entry{newTestEntry(4, 6), newTestEntry(5, 6)},
+			[]eraftpb.Entry{newTestEntry(3, 3), newTestEntry(4, 6), newTestEntry(5, 6)},
+			[]eraftpb.Entry{newTestEntry(4, 6), newTestEntry(5, 6)},
 		},
 		{
-			[]raftpb.Entry{
+			[]eraftpb.Entry{
 				newTestEntry(3, 3),
 				newTestEntry(4, 4),
 				newTestEntry(5, 5),
 				newTestEntry(6, 5),
 			},
-			[]raftpb.Entry{newTestEntry(4, 4), newTestEntry(5, 5), newTestEntry(6, 5)},
+			[]eraftpb.Entry{newTestEntry(4, 4), newTestEntry(5, 5), newTestEntry(6, 5)},
 		},
 		// truncate incoming entries, truncate the existing entries and append
 		{
-			[]raftpb.Entry{newTestEntry(2, 3), newTestEntry(3, 3), newTestEntry(4, 5)},
-			[]raftpb.Entry{newTestEntry(4, 5)},
+			[]eraftpb.Entry{newTestEntry(2, 3), newTestEntry(3, 3), newTestEntry(4, 5)},
+			[]eraftpb.Entry{newTestEntry(4, 5)},
 		},
 		// truncate the existing entries and append
-		{[]raftpb.Entry{newTestEntry(4, 5)}, []raftpb.Entry{newTestEntry(4, 5)}},
+		{[]eraftpb.Entry{newTestEntry(4, 5)}, []eraftpb.Entry{newTestEntry(4, 5)}},
 		// direct append
 		{
-			[]raftpb.Entry{newTestEntry(6, 5)},
-			[]raftpb.Entry{newTestEntry(4, 4), newTestEntry(5, 5), newTestEntry(6, 5)},
+			[]eraftpb.Entry{newTestEntry(6, 5)},
+			[]eraftpb.Entry{newTestEntry(4, 4), newTestEntry(5, 5), newTestEntry(6, 5)},
 		},
 	}
 	for _, tt := range tests {
@@ -261,7 +261,7 @@ func TestPeerStorageAppend(t *testing.T) {
 }
 
 func TestPeerStorageCacheFetch(t *testing.T) {
-	ents := []raftpb.Entry{
+	ents := []eraftpb.Entry{
 		newTestEntry(3, 3), newTestEntry(4, 4), newTestEntry(5, 5)}
 	peerStore := newTestPeerStorageFromEnts(t, ents)
 	defer cleanUpTestData(peerStore)
@@ -271,7 +271,7 @@ func TestPeerStorageCacheFetch(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, fetched, ents[1:])
 
-	entries := []raftpb.Entry{newTestEntry(6, 5), newTestEntry(7, 5)}
+	entries := []eraftpb.Entry{newTestEntry(6, 5), newTestEntry(7, 5)}
 	appendEnts(t, peerStore, entries)
 	validateCache(t, peerStore, entries)
 
@@ -283,14 +283,14 @@ func TestPeerStorageCacheFetch(t *testing.T) {
 	// size limit should be supported correctly.
 	fetched, err = peerStore.Entries(4, 8, 0)
 	assert.Nil(t, err)
-	assert.Equal(t, []raftpb.Entry{newTestEntry(4, 4)}, fetched)
+	assert.Equal(t, []eraftpb.Entry{newTestEntry(4, 4)}, fetched)
 	var size uint64
 	for _, e := range ents[1:] {
 		size += uint64(e.Size())
 	}
 	fetched, err = peerStore.Entries(4, 8, size)
 	assert.Nil(t, err)
-	var expRes []raftpb.Entry
+	var expRes []eraftpb.Entry
 	expRes = append(expRes, ents[1:]...)
 	assert.Equal(t, expRes, fetched)
 	for _, e := range entries {
@@ -311,41 +311,41 @@ func TestPeerStorageCacheFetch(t *testing.T) {
 }
 
 func TestPeerStorageCacheUpdate(t *testing.T) {
-	ents := []raftpb.Entry{
+	ents := []eraftpb.Entry{
 		newTestEntry(3, 3), newTestEntry(4, 4), newTestEntry(5, 5)}
 	peerStore := newTestPeerStorageFromEnts(t, ents)
 	defer cleanUpTestData(peerStore)
 	peerStore.cache.cache = nil
 
 	// initial cache
-	entries := []raftpb.Entry{newTestEntry(6, 5), newTestEntry(7, 5)}
+	entries := []eraftpb.Entry{newTestEntry(6, 5), newTestEntry(7, 5)}
 	appendEnts(t, peerStore, entries)
 	validateCache(t, peerStore, entries)
 
 	// rewrite
-	entries = []raftpb.Entry{newTestEntry(6, 6), newTestEntry(7, 6)}
+	entries = []eraftpb.Entry{newTestEntry(6, 6), newTestEntry(7, 6)}
 	appendEnts(t, peerStore, entries)
 	validateCache(t, peerStore, entries)
 
 	// rewrite old entry
-	entries = []raftpb.Entry{newTestEntry(5, 6), newTestEntry(6, 6)}
+	entries = []eraftpb.Entry{newTestEntry(5, 6), newTestEntry(6, 6)}
 	appendEnts(t, peerStore, entries)
 	validateCache(t, peerStore, entries)
 
 	// partial rewrite
-	entries = []raftpb.Entry{newTestEntry(6, 7), newTestEntry(7, 7)}
+	entries = []eraftpb.Entry{newTestEntry(6, 7), newTestEntry(7, 7)}
 	appendEnts(t, peerStore, entries)
-	expRes := []raftpb.Entry{newTestEntry(5, 6), newTestEntry(6, 7), newTestEntry(7, 7)}
+	expRes := []eraftpb.Entry{newTestEntry(5, 6), newTestEntry(6, 7), newTestEntry(7, 7)}
 	validateCache(t, peerStore, expRes)
 
 	// direct append
-	entries = []raftpb.Entry{newTestEntry(8, 7), newTestEntry(9, 7)}
+	entries = []eraftpb.Entry{newTestEntry(8, 7), newTestEntry(9, 7)}
 	appendEnts(t, peerStore, entries)
 	expRes = append(expRes, entries...)
 	validateCache(t, peerStore, expRes)
 
 	// rewrite middle
-	entries = []raftpb.Entry{newTestEntry(7, 8)}
+	entries = []eraftpb.Entry{newTestEntry(7, 8)}
 	appendEnts(t, peerStore, entries)
 	expRes = expRes[:2]
 	expRes = append(expRes, newTestEntry(7, 8))
@@ -380,11 +380,11 @@ func TestPeerStorageCacheUpdate(t *testing.T) {
 	validateCache(t, peerStore, expRes)
 
 	// We do not use VecDeque, so no need to test shrink.
-	appendEnts(t, peerStore, []raftpb.Entry{newTestEntry(capacity, 8)})
+	appendEnts(t, peerStore, []eraftpb.Entry{newTestEntry(capacity, 8)})
 
 	// compact all
 	peerStore.CompactTo(capacity + 2)
-	validateCache(t, peerStore, []raftpb.Entry{})
+	validateCache(t, peerStore, []eraftpb.Entry{})
 	// invalid compaction should be ignored.
 	peerStore.CompactTo(capacity)
 }

--- a/tikv/raftstore/peer_storage_test.go
+++ b/tikv/raftstore/peer_storage_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/coocood/badger"
-	"github.com/zhangjinpeng1987/raft/raft"
+	"github.com/zhangjinpeng1987/raft"
 	"github.com/pingcap/kvproto/pkg/eraftpb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/tikv/raftstore/snap.go
+++ b/tikv/raftstore/snap.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/coocood/badger"
-	"go.etcd.io/etcd/raft/raftpb"
+	"github.com/pingcap/kvproto/pkg/eraftpb"
 	"github.com/ngaut/log"
 	"github.com/ngaut/unistore/rocksdb"
 	"github.com/ngaut/unistore/util"
@@ -67,7 +67,7 @@ func (k SnapKey) String() string {
 	return fmt.Sprintf("%d_%d_%d", k.RegionID, k.Term, k.Index)
 }
 
-func SnapKeyFromRegionSnap(regionID uint64, snap *raftpb.Snapshot) SnapKey {
+func SnapKeyFromRegionSnap(regionID uint64, snap *eraftpb.Snapshot) SnapKey {
 	return SnapKey{
 		RegionID: regionID,
 		Term:     snap.Metadata.Term,
@@ -75,7 +75,7 @@ func SnapKeyFromRegionSnap(regionID uint64, snap *raftpb.Snapshot) SnapKey {
 	}
 }
 
-func SnapKeyFromSnap(snap *raftpb.Snapshot) (SnapKey, error) {
+func SnapKeyFromSnap(snap *eraftpb.Snapshot) (SnapKey, error) {
 	data := new(rspb.RaftSnapshotData)
 	err := data.Unmarshal(snap.Data)
 	if err != nil {

--- a/tikv/raftstore/test_util_test.go
+++ b/tikv/raftstore/test_util_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/coocood/badger"
-	"go.etcd.io/etcd/raft/raftpb"
+	"github.com/pingcap/kvproto/pkg/eraftpb"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/stretchr/testify/require"
 )
@@ -68,7 +68,7 @@ func newTestPeerStorage(t *testing.T) *PeerStorage {
 	return peerStore
 }
 
-func newTestPeerStorageFromEnts(t *testing.T, ents []raftpb.Entry) *PeerStorage {
+func newTestPeerStorageFromEnts(t *testing.T, ents []eraftpb.Entry) *PeerStorage {
 	peerStore := newTestPeerStorage(t)
 	kvWB := new(WriteBatch)
 	ctx := NewInvokeContext(peerStore)
@@ -90,8 +90,8 @@ func cleanUpTestData(peerStore *PeerStorage) {
 	os.RemoveAll(peerStore.Engines.raftPath)
 }
 
-func newTestEntry(index, term uint64) raftpb.Entry {
-	return raftpb.Entry{
+func newTestEntry(index, term uint64) eraftpb.Entry {
+	return eraftpb.Entry{
 		Index: index,
 		Term:  term,
 		Data:  []byte{0},


### PR DESCRIPTION
Signed-off-by: zhangjinpeng1987 <zhangjinpeng@pingcap.com>
Etcd use its own proto file, there are some conflicts with kvproto/eraftpb.