### PR TITLE
port PeerFsm step 2

### DIFF
--- a/tikv/raftstore/fsm_apply.go
+++ b/tikv/raftstore/fsm_apply.go
@@ -1,5 +1,43 @@
 package raftstore
 
+import (
+	"github.com/pingcap/kvproto/pkg/eraftpb"
+	rspb "github.com/pingcap/kvproto/pkg/raft_serverpb"
+)
+
+type ApplyTask struct {
+	RegionId uint64
+	Term     uint64
+	Entries  []eraftpb.Entry
+}
+
+type ApplyMetrics struct {
+	SizeDiffHint       uint64
+	DeleteKeysHint     uint64
+	WrittenBytes       uint64
+	WrittenKeys        uint64
+	LockCfWrittenBytes uint64
+}
+
+type ApplyTaskRes struct {
+	regionID         uint64
+	applyState       rspb.RaftApplyState
+	appliedIndexTerm uint64
+	execResults      []execResult
+	metrics          *ApplyMetrics
+	merged           bool
+
+	destroyPeerID uint64
+}
+
 type execResult struct {
 	// TODO: place holder
+}
+
+type ApplyRouter struct {
+	// Todo: currently it is a place holder
+}
+
+func (a *ApplyRouter) ScheduleTask(regionId uint64, task *ApplyTask) {
+	// Todo: currently it is a place holder
 }

--- a/tikv/raftstore/fsm_peer.go
+++ b/tikv/raftstore/fsm_peer.go
@@ -525,7 +525,7 @@ func (d *peerFsmDelegate) needGCMerge(msg *rspb.RaftMessage) (bool, error) {
 
 func (d *peerFsmDelegate) handleGCPeerMsg(msg *rspb.RaftMessage) {
 	fromEpoch := msg.RegionEpoch
-	if !IsEpochStale(fromEpoch, d.peer.Region().RegionEpoch) {
+	if !IsEpochStale(d.peer.Region().RegionEpoch, fromEpoch) {
 		return
 	}
 	if !PeerEqual(d.peer.Peer, msg.ToPeer) {

--- a/tikv/raftstore/fsm_peer.go
+++ b/tikv/raftstore/fsm_peer.go
@@ -1,6 +1,9 @@
 package raftstore
 
 import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
 	"time"
 
 	"github.com/coocood/badger/y"
@@ -19,26 +22,26 @@ type peerFsm struct {
 	stopped  bool
 	hasReady bool
 	mailbox  *mailbox
-	receiver <-chan *Msg
+	receiver <-chan Msg
 }
 
 // If we create the peer actively, like bootstrap/split/merge region, we should
 // use this function to create the peer. The region must contain the peer info
 // for this store.
 func createPeerFsm(storeID uint64, cfg *Config, sched chan<- *RegionTask,
-	engines *Engines, region *metapb.Region) (chan<- *Msg, *peerFsm, error) {
+	engines *Engines, region *metapb.Region) (chan<- Msg, *peerFsm, error) {
 	metaPeer := findPeer(region, storeID)
 	if metaPeer == nil {
 		return nil, nil, errors.Errorf("find no peer for store %d in region %v", storeID, region)
 	}
 	metaPeer = ClonePeer(metaPeer)
 	log.Infof("region %v create peer with ID %d", region, metaPeer.Id)
-	ch := make(chan *Msg, msgDefaultChanSize)
+	ch := make(chan Msg, msgDefaultChanSize)
 	peer, err := NewPeer(storeID, cfg, engines, region, sched, metaPeer)
 	if err != nil {
 		return nil, nil, err
 	}
-	return (chan<- *Msg)(ch), &peerFsm{
+	return (chan<- Msg)(ch), &peerFsm{
 		peer:     peer,
 		receiver: ch,
 	}, nil
@@ -48,18 +51,18 @@ func createPeerFsm(storeID uint64, cfg *Config, sched chan<- *RegionTask,
 // know the region_id and peer_id when creating this replicated peer, the region info
 // will be retrieved later after applying snapshot.
 func replicatePeerFsm(storeID uint64, cfg *Config, sched chan<- *RegionTask,
-	engines *Engines, regionID uint64, metaPeer *metapb.Peer) (chan<- *Msg, *peerFsm, error) {
+	engines *Engines, regionID uint64, metaPeer *metapb.Peer) (chan<- Msg, *peerFsm, error) {
 	// We will remove tombstone key when apply snapshot
 	log.Infof("[region %v] replicates peer with ID %d", regionID, metaPeer.GetId())
 	region := &metapb.Region{
 		Id: regionID,
 	}
-	ch := make(chan *Msg, msgDefaultChanSize)
+	ch := make(chan Msg, msgDefaultChanSize)
 	peer, err := NewPeer(storeID, cfg, engines, region, sched, metaPeer)
 	if err != nil {
 		return nil, nil, err
 	}
-	return (chan<- *Msg)(ch), &peerFsm{
+	return (chan<- Msg)(ch), &peerFsm{
 		peer:     peer,
 		receiver: ch,
 	}, nil
@@ -73,9 +76,9 @@ func (pf *peerFsm) drop() {
 			var cb Callback
 			switch msg.Type {
 			case MsgTypeRaftCmd:
-				cb = msg.RaftCMD.Callback
+				cb = msg.Data.(*MsgRaftCmd).Callback
 			case MsgTypeSplitRegion:
-				cb = msg.SplitRegion.Callback
+				cb = msg.Data.(*MsgSplitRegion).Callback
 			default:
 				continue
 			}
@@ -148,43 +151,50 @@ func (d *peerFsmDelegate) tag() string {
 	return d.peer.Tag
 }
 
-func (d *peerFsmDelegate) handleMsgs(msgs []*Msg) {
+func (d *peerFsmDelegate) handleMsgs(msgs []Msg) {
 	for _, msg := range msgs {
 		switch msg.Type {
 		case MsgTypeRaftMessage:
-			if err := d.onRaftMsg(msg.RaftMsg); err != nil {
+			raftMsg := msg.Data.(*rspb.RaftMessage)
+			if err := d.onRaftMsg(raftMsg); err != nil {
 				log.Errorf("%s handle raft message error %v", d.peer.Tag, err)
 			}
 		case MsgTypeRaftCmd:
-			d.proposeRaftCommand(msg.RaftCMD.Request, msg.RaftCMD.Callback)
+			raftCMD := msg.Data.(*MsgRaftCmd)
+			d.proposeRaftCommand(raftCMD.Request, raftCMD.Callback)
 		case MsgTypeTick:
-			d.onTick(msg.Tick)
+			d.onTick()
 		case MsgTypeApplyRes:
+			res := msg.Data.(*ApplyTaskRes)
 			if state := d.peer.PendingMergeApplyResult; state != nil {
-				state.results = append(state.results, msg.ApplyRes)
+				state.results = append(state.results, res)
 				continue
 			}
-			d.onApplyResult(msg.ApplyRes)
+			d.onApplyResult(res)
 		case MsgTypeSignificantMsg:
-			d.onSignificantMsg(msg.Significant)
+			d.onSignificantMsg(msg.Data.(*MsgSignificant))
 		case MsgTypeSplitRegion:
-			split := msg.SplitRegion
+			split := msg.Data.(*MsgSplitRegion)
 			log.Infof("%s on split with %v", d.peer.Tag, split.SplitKeys)
 			d.onPrepareSplitRegion(split.RegionEpoch, split.SplitKeys, split.Callback)
 		case MsgTypeComputeResult:
-			d.onHashComputed(msg.ComputeHashResult.Index, msg.ComputeHashResult.Hash)
+			result := msg.Data.(*MsgComputeHashResult)
+			d.onHashComputed(result.Index, result.Hash)
 		case MsgTypeRegionApproximateSize:
-			d.onApproximateRegionSize(msg.RegionApproximateSize)
+			d.onApproximateRegionSize(msg.Data.(uint64))
 		case MsgTypeRegionApproximateKeys:
-			d.onApprocximateRegionKeys(msg.RegionApproximateKeys)
+			d.onApprocximateRegionKeys(msg.Data.(uint64))
 		case MsgTypeCompactionDeclineBytes:
-			d.onCompactionDeclinedBytes(msg.ComputeDeclinedBytes)
+			d.onCompactionDeclinedBytes(msg.Data.(uint64))
 		case MsgTypeHalfSplitRegion:
-			d.onScheduleHalfSplitRegion(msg.HalfSplitRegion.RegionEpoch, msg.HalfSplitRegion.Policy)
+			half := msg.Data.(*MsgHalfSplitRegion)
+			d.onScheduleHalfSplitRegion(half.RegionEpoch, half.Policy)
 		case MsgTypeMergeResult:
-			d.onMergeResult(msg.MergeResult.TargetPeer, msg.MergeResult.Stale)
+			result := msg.Data.(*MsgMergeResult)
+			d.onMergeResult(result.TargetPeer, result.Stale)
 		case MsgTypeGcSnap:
-			d.onGCSnap(msg.GCSnap.Snaps)
+			gcSnap := msg.Data.(*MsgGCSnap)
+			d.onGCSnap(gcSnap.Snaps)
 		case MsgTypeClearRegionSize:
 			d.onClearRegionSize()
 		case MsgTypeStart:
@@ -194,7 +204,7 @@ func (d *peerFsmDelegate) handleMsgs(msgs []*Msg) {
 	}
 }
 
-func (d *peerFsmDelegate) onTick(tick PeerTick) {
+func (d *peerFsmDelegate) onTick() {
 	if d.stopped {
 		return
 	}
@@ -224,7 +234,7 @@ func (d *peerFsmDelegate) start() {
 		d.notifyPrepareMerge()
 	}
 	d.ticker = newTicker(d.regionID(), d.ctx.Cfg)
-	d.ctx.newTickerCh <- d.ticker
+	d.ctx.tickDriverCh <- d.regionID()
 	d.ticker.schedule(PeerTickRaft)
 	d.ticker.schedule(PeerTickRaftLogGC)
 	d.ticker.schedule(PeerTickSplitRegionCheck)
@@ -464,7 +474,49 @@ func (d *peerFsmDelegate) validateRaftMessage(msg *rspb.RaftMessage) bool {
 ///
 /// Returns true means that the message can be dropped silently.
 func (d *peerFsmDelegate) checkMessage(msg *rspb.RaftMessage) bool {
-	return false // TODO: stub
+	fromEpoch := msg.GetRegionEpoch()
+	isVoteMsg := isVoteMessage(msg.Message)
+	fromStoreID := msg.FromPeer.GetStoreId()
+
+	// Let's consider following cases with three nodes [1, 2, 3] and 1 is leader:
+	// a. 1 removes 2, 2 may still send MsgAppendResponse to 1.
+	//  We should ignore this stale message and let 2 remove itself after
+	//  applying the ConfChange log.
+	// b. 2 is isolated, 1 removes 2. When 2 rejoins the cluster, 2 will
+	//  send stale MsgRequestVote to 1 and 3, at this time, we should tell 2 to gc itself.
+	// c. 2 is isolated but can communicate with 3. 1 removes 3.
+	//  2 will send stale MsgRequestVote to 3, 3 should ignore this message.
+	// d. 2 is isolated but can communicate with 3. 1 removes 2, then adds 4, remove 3.
+	//  2 will send stale MsgRequestVote to 3, 3 should tell 2 to gc itself.
+	// e. 2 is isolated. 1 adds 4, 5, 6, removes 3, 1. Now assume 4 is leader.
+	//  After 2 rejoins the cluster, 2 may send stale MsgRequestVote to 1 and 3,
+	//  1 and 3 will ignore this message. Later 4 will send messages to 2 and 2 will
+	//  rejoin the raft group again.
+	// f. 2 is isolated. 1 adds 4, 5, 6, removes 3, 1. Now assume 4 is leader, and 4 removes 2.
+	//  unlike case e, 2 will be stale forever.
+	// TODO: for case f, if 2 is stale for a long time, 2 will communicate with pd and pd will
+	// tell 2 is stale, so 2 can remove itself.
+	region := d.peer.Region()
+	if IsEpochStale(fromEpoch, region.RegionEpoch) && findPeer(region, fromStoreID) == nil {
+		// The message is stale and not in current region.
+		d.ctx.handleStaleMsg(msg, region.RegionEpoch, isVoteMsg, nil)
+		return true
+	}
+	target := msg.GetToPeer()
+	if target.Id < d.peerID() {
+		log.Infof("%s target peer ID %d is less than %d, msg maybe stale", d.tag(), target.Id, d.peerID())
+		return true
+	} else if target.Id > d.peerID() {
+		if job := d.peer.MaybeDestroy(); job != nil {
+			log.Infof("%s is stale as received a larger peer %s, destroying", d.tag(), target)
+			if d.handleDestroyPeer(job) {
+				storeMsg := Msg{Type: MsgTypeRaftMessage, Data: msg}
+				d.ctx.router.sendControl(storeMsg)
+			}
+		}
+		return true
+	}
+	return false
 }
 
 func (d *peerFsmDelegate) needGCMerge(msg *rspb.RaftMessage) (bool, error) {
@@ -472,11 +524,115 @@ func (d *peerFsmDelegate) needGCMerge(msg *rspb.RaftMessage) (bool, error) {
 }
 
 func (d *peerFsmDelegate) handleGCPeerMsg(msg *rspb.RaftMessage) {
-	// TODO: stub
+	fromEpoch := msg.RegionEpoch
+	if !IsEpochStale(fromEpoch, d.peer.Region().RegionEpoch) {
+		return
+	}
+	if !PeerEqual(d.peer.Peer, msg.ToPeer) {
+		log.Infof("%s receive stale gc msg, ignore", d.tag())
+		return
+	}
+	// TODO: ask pd to guarantee we are stale now.
+	log.Infof("%s peer %s receives gc message, trying to remove", d.tag(), msg.ToPeer)
+	if job := d.peer.MaybeDestroy(); job != nil {
+		d.handleDestroyPeer(job)
+	}
 }
 
+// Returns `None` if the `msg` doesn't contain a snapshot or it contains a snapshot which
+// doesn't conflict with any other snapshots or regions. Otherwise a `SnapKey` is returned.
 func (d *peerFsmDelegate) checkSnapshot(msg *rspb.RaftMessage) (*SnapKey, error) {
-	return nil, nil // TODO: stub
+	if msg.Message.Snapshot == nil {
+		return nil, nil
+	}
+	regionID := msg.RegionId
+	snap := msg.Message.Snapshot
+	key := SnapKeyFromRegionSnap(regionID, snap)
+	snapData := new(rspb.RaftSnapshotData)
+	err := snapData.Unmarshal(snap.Data)
+	if err != nil {
+		return nil, err
+	}
+	snapRegion := snapData.Region
+	peerID := msg.ToPeer.Id
+	var contains bool
+	for _, peer := range snapRegion.Peers {
+		if peer.Id == peerID {
+			contains = true
+			break
+		}
+	}
+	if !contains {
+		log.Infof("%s %s doesn't contains peer %d, skip", d.tag(), snapRegion, peerID)
+		return &key, nil
+	}
+
+	d.ctx.storeMetaLock.Lock()
+	defer d.ctx.storeMetaLock.Unlock()
+	meta := d.ctx.storeMeta
+	if !RegionEqual(meta.regions[d.regionID()], d.region()) {
+		if !d.peer.isInitialized() {
+			log.Infof("%s stale delegate detected, skip", d.tag())
+			return &key, nil
+		} else {
+			panic(fmt.Sprintf("%s meta corrupted %s != %s", d.tag(), meta.regions[d.regionID()], d.region()))
+		}
+	}
+	existOverlapRegion := d.findOverlapRegion(meta, snapRegion)
+	if existOverlapRegion != nil {
+		log.Infof("%s region overlapped %s %s", d.tag(), existOverlapRegion, snapRegion)
+		// In some extreme case, it may happen that a new snapshot is received whereas a snapshot is still in applying
+		// if the snapshot under applying is generated before merge and the new snapshot is generated after merge,
+		// update `pending_cross_snap` here may cause source peer destroys itself improperly. So don't update
+		// `pending_cross_snap` here if peer is applying snapshot.
+		if !d.peer.IsApplyingSnapshot() && !d.peer.HasPendingSnapshot() {
+			meta.pendingCrossSnap[regionID] = snapRegion.RegionEpoch
+		}
+		return &key, nil
+	}
+	for _, region := range meta.pendingSnapshotRegions {
+		if bytes.Compare(region.StartKey, snapRegion.EndKey) < 0 &&
+			bytes.Compare(region.EndKey, snapRegion.StartKey) > 0 &&
+			// Same region can overlap, we will apply the latest version of snapshot.
+			region.Id != snapRegion.Id {
+			log.Infof("%s pending region overlapped %s, %s", d.tag(), region, snapRegion)
+			return &key, nil
+		}
+	}
+	if r, ok := meta.pendingCrossSnap[regionID]; ok {
+		if IsEpochStale(snapRegion.RegionEpoch, r) {
+			log.Infof("%s snapshot epoch is stale %s, %s, drop", d.tag(), snapRegion.RegionEpoch, r)
+			return &key, nil
+		}
+	}
+	// check if snapshot file exists.
+	_, err = d.ctx.snapMgr.GetSnapshotForApplying(key)
+	if err != nil {
+		return nil, err
+	}
+	meta.pendingSnapshotRegions = append(meta.pendingSnapshotRegions, snapRegion)
+	d.ctx.queuedSnaps[regionID] = struct{}{}
+	delete(meta.pendingCrossSnap, regionID)
+	return nil, nil
+}
+
+func (d *peerFsmDelegate) findOverlapRegion(storeMeta *storeMeta, snapRegion *metapb.Region) *metapb.Region {
+	it := storeMeta.regionRanges.NewIterator()
+	it.Seek(snapRegion.StartKey)
+	for it.Valid() {
+		regionID := binary.LittleEndian.Uint64(it.Value())
+		if bytes.Equal(it.Key(), snapRegion.StartKey) || regionID == snapRegion.Id {
+			it.Next()
+			continue
+		}
+		region := storeMeta.regions[regionID]
+		if bytes.Compare(region.StartKey, snapRegion.EndKey) < 0 {
+			return region
+		} else {
+			return nil
+		}
+	}
+	return nil
 }
 
 func (d *peerFsmDelegate) handleDestroyPeer(job *DestroyPeerJob) bool {

--- a/tikv/raftstore/fsm_store.go
+++ b/tikv/raftstore/fsm_store.go
@@ -1,5 +1,88 @@
 package raftstore
 
+import (
+	"github.com/ngaut/log"
+	"github.com/ngaut/unistore/lockstore"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	rspb "github.com/pingcap/kvproto/pkg/raft_serverpb"
+	"sync"
+)
+
 type storeMeta struct {
-	// TODO: placeholder
+	// region end key -> region ID
+	regionRanges           *lockstore.MemStore
+	regions                map[uint64]*metapb.Region
+	pendingCrossSnap       map[uint64]*metapb.RegionEpoch
+	pendingSnapshotRegions []*metapb.Region
+}
+
+type PollContext struct {
+	Cfg             *Config
+	CoprocessorHost *CoprocessorHost
+	engine          *Engines
+	dbBundle        *DBBundle
+	applyRouter     *ApplyRouter
+	needFlushTrans  bool
+	ReadyRes        []ReadyICPair
+	kvWB            *WriteBatch
+	raftWB          *WriteBatch
+	syncLog         bool
+	storeMeta       *storeMeta
+	storeMetaLock   sync.Mutex
+	snapMgr         *SnapManager
+	pendingCount    int
+	hasReady        bool
+	router          *router
+	tickDriverCh    chan<- uint64
+	trans           Transport
+	queuedSnaps     map[uint64]struct{}
+}
+
+type Transport interface {
+	Send(msg *rspb.RaftMessage) error
+}
+
+func (pc *PollContext) KVWB() *WriteBatch {
+	return pc.kvWB
+}
+
+func (pc *PollContext) RaftWB() *WriteBatch {
+	return pc.raftWB
+}
+
+func (pc *PollContext) SyncLog() bool {
+	return pc.syncLog
+}
+
+func (pc *PollContext) SetSyncLog(sync bool) {
+	pc.syncLog = sync
+}
+
+func (pc *PollContext) handleStaleMsg(msg *rspb.RaftMessage, curEpoch *metapb.RegionEpoch,
+	needGC bool, targetRegion *metapb.Region) {
+	regionID := msg.RegionId
+	fromPeer := msg.FromPeer
+	toPeer := msg.ToPeer
+	msgType := msg.Message.GetMsgType()
+
+	if !needGC {
+		log.Infof("[region %d] raft message %s is stale, current %v ignore it",
+			regionID, msgType, curEpoch)
+		return
+	}
+	gcMsg := &rspb.RaftMessage{
+		RegionId:    regionID,
+		FromPeer:    ClonePeer(fromPeer),
+		ToPeer:      ClonePeer(toPeer),
+		RegionEpoch: CloneRegionEpoch(curEpoch),
+	}
+	if targetRegion != nil {
+		gcMsg.MergeTarget = targetRegion
+	} else {
+		gcMsg.IsTombstone = true
+	}
+	err := pc.trans.Send(gcMsg)
+	if err != nil {
+		log.Errorf("[region %d] send message failed %v", regionID, err)
+	}
 }

--- a/tikv/raftstore/fsm_store.go
+++ b/tikv/raftstore/fsm_store.go
@@ -81,8 +81,7 @@ func (pc *PollContext) handleStaleMsg(msg *rspb.RaftMessage, curEpoch *metapb.Re
 	} else {
 		gcMsg.IsTombstone = true
 	}
-	err := pc.trans.Send(gcMsg)
-	if err != nil {
+	if err := pc.trans.Send(gcMsg); err != nil {
 		log.Errorf("[region %d] send message failed %v", regionID, err)
 	}
 }

--- a/tikv/raftstore/msg.go
+++ b/tikv/raftstore/msg.go
@@ -3,18 +3,17 @@ package raftstore
 import (
 	"time"
 
-	"github.com/ngaut/unistore/rocksdb"
 	"github.com/pingcap/kvproto/pkg/import_sstpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/kvproto/pkg/raft_cmdpb"
-	"github.com/pingcap/kvproto/pkg/raft_serverpb"
 	"github.com/zhangjinpeng1987/raft"
 )
 
-type MsgType int
+type MsgType int64
 
 const (
+	MsgTypeNull                   MsgType = 0
 	MsgTypeRaftMessage            MsgType = 1
 	MsgTypeRaftCmd                MsgType = 2
 	MsgTypeSplitRegion            MsgType = 3
@@ -45,8 +44,21 @@ const (
 	MsgTypeFsmNormal  MsgType = 201
 	MsgTypeFsmControl MsgType = 202
 
+	MsgTypeApplyTask         MsgType = 301
+	MsgTypeApplyRegistration MsgType = 302
+	MsgTypeApplyProposal     MsgType = 303
+	MsgTypeApplyCatchUpLogs  MsgType = 304
+	MsgTypeApplyLogsUpToDate MsgType = 305
+	MsgTypeApplyDestroy      MsgType = 306
+
 	msgDefaultChanSize = 1024
 )
+
+type Msg struct {
+	Type     MsgType
+	RegionID uint64
+	Data     interface{}
+}
 
 type Callback func(resp *raft_cmdpb.RaftCmdResponse, snap *DBSnapshot)
 
@@ -86,37 +98,6 @@ type MsgSignificant struct {
 	Type           MsgSignificantType
 	ToPeerID       uint64
 	SnapshotStatus raft.SnapshotStatus
-}
-
-type Msg struct {
-	Type MsgType
-	// Region Messages.
-	RegionID              uint64
-	RaftMsg               *raft_serverpb.RaftMessage
-	RaftCMD               *MsgRaftCmd
-	SplitRegion           *MsgSplitRegion
-	ComputeHashResult     *MsgComputeHashResult
-	RegionApproximateSize uint64
-	RegionApproximateKeys uint64
-	ComputeDeclinedBytes  uint64
-	HalfSplitRegion       *MsgHalfSplitRegion
-	MergeResult           *MsgMergeResult
-	GCSnap                *MsgGCSnap
-	Tick                  PeerTick
-	Significant           *MsgSignificant
-	ApplyRes              *ApplyTaskRes
-	Any                   interface{}
-
-	// Store Messages.
-	StoreRaftMsg                *raft_serverpb.RaftMessage
-	StoreValidateSSTResult      *MsgStoreValidateSSTResult
-	StoreClearRegionSizeInRange *MsgStoreClearRegionSizeInRange
-	StoreCompactedEvent         *rocksdb.CompactedEvent
-	StoreTick                   StoreTick
-	StoreStartStore             *metapb.Store
-
-	// fsm Message.
-	Fsm fsm
 }
 
 type MsgRaftCmd struct {

--- a/tikv/raftstore/peer_storage.go
+++ b/tikv/raftstore/peer_storage.go
@@ -822,6 +822,13 @@ func PeerEqual(l, r *metapb.Peer) bool {
 	return l.Id == r.Id && l.StoreId == r.StoreId && l.IsLearner == r.IsLearner
 }
 
+func RegionEqual(l, r *metapb.Region) bool {
+	if l == nil || r == nil {
+		return false
+	}
+	return l.Id == r.Id && l.RegionEpoch.Version == r.RegionEpoch.Version && l.RegionEpoch.ConfVer == r.RegionEpoch.ConfVer
+}
+
 func ClonePeer(peer *metapb.Peer) *metapb.Peer {
 	return &metapb.Peer{
 		Id:        peer.Id,
@@ -835,7 +842,7 @@ func CloneRegion(region *metapb.Region) *metapb.Region {
 	cloned.Id = region.Id
 	cloned.StartKey = append([]byte{}, region.StartKey...)
 	cloned.EndKey = append([]byte{}, region.EndKey...)
-	cloned.RegionEpoch = &metapb.RegionEpoch{ConfVer: region.RegionEpoch.ConfVer, Version: region.RegionEpoch.Version}
+	cloned.RegionEpoch = CloneRegionEpoch(region.RegionEpoch)
 
 	cloned.Peers = make([]*metapb.Peer, 0, len(region.Peers))
 	for _, p := range region.Peers {
@@ -843,6 +850,10 @@ func CloneRegion(region *metapb.Region) *metapb.Region {
 	}
 
 	return cloned
+}
+
+func CloneRegionEpoch(epoch *metapb.RegionEpoch) *metapb.RegionEpoch {
+	return &metapb.RegionEpoch{ConfVer: epoch.ConfVer, Version: epoch.Version}
 }
 
 func CloneMergeState(state *rspb.MergeState) *rspb.MergeState {

--- a/tikv/raftstore/snap_manager.go
+++ b/tikv/raftstore/snap_manager.go
@@ -44,9 +44,9 @@ type SnapStats struct {
 	SendingCount   int
 }
 
-func notifyStats(ch chan<- *Msg) {
+func notifyStats(ch chan<- Msg) {
 	if ch != nil {
-		ch <- &Msg{Type: MsgTypeStoreSnapshotStats}
+		ch <- Msg{Type: MsgTypeStoreSnapshotStats}
 	}
 }
 
@@ -55,12 +55,12 @@ type SnapManager struct {
 	snapSize     *int64
 	registryLock sync.RWMutex
 	registry     map[SnapKey][]SnapEntry
-	ch           chan<- *Msg
+	ch           chan<- Msg
 	limiter      *IOLimiter
 	MaxTotalSize uint64
 }
 
-func NewSnapManager(path string, ch chan<- *Msg) *SnapManager {
+func NewSnapManager(path string, ch chan<- Msg) *SnapManager {
 	return new(SnapManagerBuilder).Build(path, ch)
 }
 
@@ -340,7 +340,7 @@ func (smb *SnapManagerBuilder) MaxTotalSize(v uint64) *SnapManagerBuilder {
 	return smb
 }
 
-func (smb *SnapManagerBuilder) Build(path string, ch chan<- *Msg) *SnapManager {
+func (smb *SnapManagerBuilder) Build(path string, ch chan<- Msg) *SnapManager {
 	var maxTotalSize uint64 = math.MaxUint64
 	if smb.maxTotalSize > 0 {
 		maxTotalSize = smb.maxTotalSize


### PR DESCRIPTION
Refactor `Msg` to use `interface` instead of multiple fields.
Since the struct is small, only 32 bytes, we can use value instead of pointer.
Move some code from peer to fsm_apply and fsm_store.