### PR TITLE
disable grpc window update

### DIFF
--- a/node/main.go
+++ b/node/main.go
@@ -45,6 +45,11 @@ var (
 	gitHash = "None"
 )
 
+const (
+	grpcInitialWindowSize     = 1 << 30
+	grpcInitialConnWindowSize = 1 << 30
+)
+
 func main() {
 	flag.Parse()
 	runtime.GOMAXPROCS(*maxProcs)
@@ -82,7 +87,10 @@ func main() {
 	store := tikv.NewMVCCStore(bundle, *dbPath, safePoint, dbWriter)
 	tikvServer := tikv.NewServer(rm, store)
 
-	grpcServer := grpc.NewServer()
+	grpcServer := grpc.NewServer(
+		grpc.InitialWindowSize(grpcInitialWindowSize),
+		grpc.InitialConnWindowSize(grpcInitialConnWindowSize),
+	)
 	tikvpb.RegisterTikvServer(grpcServer, tikvServer)
 	l, err := net.Listen("tcp", *storeAddr)
 	if err != nil {


### PR DESCRIPTION
TiDB use 16 connections for each kv store (maybe it's not wise choosen) and http2 flow control seems to be useless, so int TiDB, dynamic window is disabled

https://github.com/pingcap/tidb/blob/461512b8273a7b64580cd96e34c8e2d7983b5e62/store/tikv/client.go#L249

https://github.com/grpc/grpc-go/blob/master/internal/transport/http2_client.go#L210

but unistore keep use window update frame, from TiDB scheduler pprof:

![image](https://user-images.githubusercontent.com/528332/57281642-f9a60080-70dd-11e9-87f8-5d013cd8a5d0.png)

unionstore keep send updateWindow frame to TiDB, so this PR try to disable it in unistore too

and do some sysbench point-get test:

before:

```
sysbench --config-file=tidb-config oltp_point_select --tables=32 --threads=32 --table-size=100000 run
[ 5s ] thds: 32 tps: 54212.80 qps: 54212.80 (r/w/o: 54212.80/0.00/0.00) lat (ms,95%): 1.01 err/s: 0.00 reconn/s: 0.00
[ 10s ] thds: 32 tps: 37306.71 qps: 37306.71 (r/w/o: 37306.71/0.00/0.00) lat (ms,95%): 1.58 err/s: 0.00 reconn/s: 0.00
[ 15s ] thds: 32 tps: 31182.89 qps: 31182.89 (r/w/o: 31182.89/0.00/0.00) lat (ms,95%): 1.73 err/s: 0.00 reconn/s: 0.00
[ 20s ] thds: 32 tps: 31335.87 qps: 31335.87 (r/w/o: 31335.87/0.00/0.00) lat (ms,95%): 1.73 err/s: 0.00 reconn/s: 0.00
[ 25s ] thds: 32 tps: 31371.22 qps: 31371.22 (r/w/o: 31371.22/0.00/0.00) lat (ms,95%): 1.73 err/s: 0.00 reconn/s: 0.00
[ 30s ] thds: 32 tps: 31386.28 qps: 31386.28 (r/w/o: 31386.28/0.00/0.00) lat (ms,95%): 1.76 err/s: 0.00 reconn/s: 0.00
[ 35s ] thds: 32 tps: 31403.74 qps: 31403.74 (r/w/o: 31403.74/0.00/0.00) lat (ms,95%): 1.73 err/s: 0.00 reconn/s: 0.00
[ 40s ] thds: 32 tps: 31270.10 qps: 31270.10 (r/w/o: 31270.10/0.00/0.00) lat (ms,95%): 1.73 err/s: 0.00 reconn/s: 0.00
[ 45s ] thds: 32 tps: 31571.52 qps: 31571.52 (r/w/o: 31571.52/0.00/0.00) lat (ms,95%): 1.73 err/s: 0.00 reconn/s: 0.00
```

after

```
sysbench --config-file=tidb-config oltp_point_select --tables=32 --threads=32 --table-size=100000 run
[ 5s ] thds: 32 tps: 50061.73 qps: 50061.73 (r/w/o: 50061.73/0.00/0.00) lat (ms,95%): 1.21 err/s: 0.00 reconn/s: 0.00
[ 10s ] thds: 32 tps: 32300.74 qps: 32300.74 (r/w/o: 32300.74/0.00/0.00) lat (ms,95%): 1.70 err/s: 0.00 reconn/s: 0.00
[ 15s ] thds: 32 tps: 32684.99 qps: 32684.99 (r/w/o: 32684.99/0.00/0.00) lat (ms,95%): 1.67 err/s: 0.00 reconn/s: 0.00
[ 20s ] thds: 32 tps: 32698.61 qps: 32698.61 (r/w/o: 32698.61/0.00/0.00) lat (ms,95%): 1.70 err/s: 0.00 reconn/s: 0.00
[ 25s ] thds: 32 tps: 32561.84 qps: 32561.84 (r/w/o: 32561.84/0.00/0.00) lat (ms,95%): 1.67 err/s: 0.00 reconn/s: 0.00
[ 30s ] thds: 32 tps: 32563.95 qps: 32563.95 (r/w/o: 32563.95/0.00/0.00) lat (ms,95%): 1.70 err/s: 0.00 reconn/s: 0.00
[ 35s ] thds: 32 tps: 32710.36 qps: 32710.36 (r/w/o: 32710.36/0.00/0.00) lat (ms,95%): 1.67 err/s: 0.00 reconn/s: 0.00
[ 40s ] thds: 32 tps: 32655.44 qps: 32655.44 (r/w/o: 32655.44/0.00/0.00) lat (ms,95%): 1.67 err/s: 0.00 reconn/s: 0.00
[ 45s ] thds: 32 tps: 33016.58 qps: 33016.58 (r/w/o: 33016.58/0.00/0.00) lat (ms,95%): 1.64 err/s: 0.00 reconn/s: 0.00
```
test result isn't very stablable, but it "seems" more better

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ngaut/unistore/190)
<!-- Reviewable:end -->
