### PR TITLE
use undo log to keep lock store snapshot consistent

### DIFF
--- a/tikv/raftstore/engine.go
+++ b/tikv/raftstore/engine.go
@@ -1,7 +1,10 @@
 package raftstore
 
 import (
+	"bytes"
 	"math"
+	"sync"
+	"sync/atomic"
 
 	"github.com/coocood/badger"
 	"github.com/cznic/mathutil"
@@ -10,13 +13,56 @@ import (
 	"github.com/ngaut/unistore/tikv/dbreader"
 	"github.com/ngaut/unistore/tikv/mvcc"
 	"github.com/pingcap/errors"
-	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/kvproto/pkg/raft_serverpb"
 )
 
 type DBBundle struct {
 	db            *badger.DB
 	lockStore     *lockstore.MemStore
 	rollbackStore *lockstore.MemStore
+	regionUndo    *sync.Map // map[uint64]*lockUndoLog
+	memStoreMu    sync.Mutex
+}
+
+type lockUndoLog struct {
+	refCnt      int32
+	undoEntries atomic.Value // []*undoEntry
+}
+
+func (ll *lockUndoLog) getUndoEntries() []*undoEntry {
+	es := ll.undoEntries.Load()
+	if es == nil {
+		return nil
+	}
+	return es.([]*undoEntry)
+}
+
+func (ll *lockUndoLog) resetUndoEntries() {
+	ll.undoEntries.Store([]*undoEntry{})
+}
+
+func (ll *lockUndoLog) appendUndoEntries(entries []*undoEntry) {
+	oldLog := ll.getUndoEntries()
+	newLog := make([]*undoEntry, 0, len(oldLog)+len(entries))
+	newLog = append(append(newLog, oldLog...), entries...)
+	ll.undoEntries.Store(newLog)
+}
+
+type undoEntry struct {
+	regionId  uint64
+	index     uint64
+	undoLocks []*undoLock
+}
+
+type undoLock struct {
+	isSet bool
+	key   []byte
+	val   []byte
+}
+
+func (bundle *DBBundle) getLockUndoLog(region uint64) *lockUndoLog {
+	v, _ := bundle.regionUndo.LoadOrStore(region, new(lockUndoLog))
+	return v.(*lockUndoLog)
 }
 
 type DBSnapshot struct {
@@ -33,9 +79,36 @@ func NewDBSnapshot(db *DBBundle) *DBSnapshot {
 	}
 }
 
-type RegionSnapshot struct {
-	Region   *metapb.Region
-	Snapshot *DBSnapshot
+type regionSnapshot struct {
+	regionState *raft_serverpb.RegionLocalState
+	txn         *badger.Txn
+	lockSnap    *lockstore.MemStore
+	term        uint64
+	index       uint64
+}
+
+func (rs *regionSnapshot) snapLocks(start, end []byte, lockStore *lockstore.MemStore, undoLog *lockUndoLog) {
+	rs.lockSnap = lockstore.NewMemStore(8 << 20)
+	iter := lockStore.NewIterator()
+	for iter.Seek(start); iter.Valid() && (len(end) == 0 || bytes.Compare(iter.Key(), end) < 0); iter.Next() {
+		rs.lockSnap.Insert(iter.Key(), iter.Value())
+	}
+
+	undoEntries := undoLog.getUndoEntries()
+	for i := len(undoEntries) - 1; i >= 0; i-- {
+		undo := undoEntries[i]
+		if undo.index <= rs.index {
+			break
+		}
+		for j := len(undo.undoLocks) - 1; j >= 0; j-- {
+			undoLock := undo.undoLocks[j]
+			if undoLock.isSet {
+				rs.lockSnap.Delete(undoLock.key)
+			} else {
+				rs.lockSnap.Insert(undoLock.key, undoLock.val)
+			}
+		}
+	}
 }
 
 type Engines struct {
@@ -51,11 +124,45 @@ func NewEngines(kvEngine *mvcc.DBBundle, raftEngine *badger.DB, kvPath, raftPath
 			db:            kvEngine.DB,
 			lockStore:     kvEngine.LockStore,
 			rollbackStore: kvEngine.RollbackStore,
+			regionUndo:    new(sync.Map),
 		},
 		kvPath:   kvPath,
 		raft:     raftEngine,
 		raftPath: raftPath,
 	}
+}
+
+func (en *Engines) newRegionSnapshot(regionId uint64) (snap *regionSnapshot, err error) {
+	undoLog := en.kv.getLockUndoLog(regionId)
+
+	// Acquire lockstore undo logs before snapshot db.
+	// Otherwise apply worker may release undo logs after raft index in db snapshot.
+	atomic.AddInt32(&undoLog.refCnt, 1)
+	txn := en.kv.db.NewTransaction(false)
+	snap = &regionSnapshot{
+		regionState: new(raft_serverpb.RegionLocalState),
+		txn:         txn,
+	}
+
+	snap.index, snap.term, err = getAppliedIdxTermForSnapshot(en.raft, txn, regionId)
+	if err != nil {
+		return nil, err
+	}
+
+	stateVal, err := getValueTxn(txn, RegionStateKey(regionId))
+	if err != nil {
+		return nil, err
+	}
+	if err := snap.regionState.Unmarshal(stateVal); err != nil {
+		return nil, err
+	}
+
+	region := snap.regionState.GetRegion()
+	start, end := rawDataStartKey(region.StartKey), rawRegionKey(region.EndKey)
+	snap.snapLocks(start, end, en.kv.lockStore, undoLog)
+	atomic.AddInt32(&undoLog.refCnt, -1)
+
+	return snap, nil
 }
 
 func (en *Engines) WriteKV(wb *WriteBatch) error {
@@ -78,11 +185,20 @@ func (en *Engines) SyncRaftWAL() error {
 
 type WriteBatch struct {
 	entries       []*badger.Entry
+	lockEntries   []*badger.Entry
+	undoEntries   []*undoEntry
 	size          int
 	safePoint     int
 	safePointLock int
 	safePointSize int
-	lockEntries   []*badger.Entry
+	safePointUndo int
+}
+
+func (wb *WriteBatch) NewUndoAt(region, index uint64) {
+	wb.undoEntries = append(wb.undoEntries, &undoEntry{
+		regionId: region,
+		index:    index,
+	})
 }
 
 func (wb *WriteBatch) Len() int {
@@ -103,13 +219,25 @@ func (wb *WriteBatch) SetLock(key, val []byte) {
 		Value:    val,
 		UserMeta: mvcc.LockUserMetaNone,
 	})
+	undo := wb.undoEntries[len(wb.undoEntries)-1]
+	undo.undoLocks = append(undo.undoLocks, &undoLock{
+		isSet: true,
+		key:   key,
+	})
 }
 
-func (wb *WriteBatch) DeleteLock(key []byte) {
+func (wb *WriteBatch) DeleteLock(key []byte, val []byte) {
 	wb.lockEntries = append(wb.lockEntries, &badger.Entry{
 		Key:      key,
 		UserMeta: mvcc.LockUserMetaDelete,
 	})
+	if len(val) != 0 {
+		undo := wb.undoEntries[len(wb.undoEntries)-1]
+		undo.undoLocks = append(undo.undoLocks, &undoLock{
+			key: key,
+			val: val,
+		})
+	}
 }
 
 func (wb *WriteBatch) Rollback(key []byte) {
@@ -147,20 +275,48 @@ func (wb *WriteBatch) SetMsg(key []byte, msg proto.Message) error {
 func (wb *WriteBatch) SetSafePoint() {
 	wb.safePoint = len(wb.entries)
 	wb.safePointLock = len(wb.lockEntries)
+	wb.safePointUndo = len(wb.undoEntries)
 	wb.safePointSize = wb.size
 }
 
 func (wb *WriteBatch) RollbackToSafePoint() {
 	wb.entries = wb.entries[:wb.safePoint]
 	wb.lockEntries = wb.lockEntries[:wb.safePointLock]
+	wb.undoEntries = wb.undoEntries[:wb.safePointUndo]
 	wb.size = wb.safePointSize
 }
 
+// WriteToKV flush WriteBatch to DB by three steps:
+// 	1. Flush undo log.
+//	2. Update lockstore. Because we have save undo log, ongoing snapshot can revert dirty locks by replay undo log.
+// 	3. Write entries to badger. After save ApplyState to badger, subsequent regionSnapshot will start at new raft index.
+// 	   So we can safely release all undo logs if there is no ongoing snapshot progress.
 func (wb *WriteBatch) WriteToKV(bundle *DBBundle) error {
+	if len(wb.undoEntries) > 0 {
+		currRegion := wb.undoEntries[0].regionId
+		undoLog := bundle.getLockUndoLog(currRegion)
+		var undoBuf []*undoEntry
+		for _, undo := range wb.undoEntries {
+			if undo.regionId != currRegion {
+				undoLog.appendUndoEntries(undoBuf)
+				undoBuf = undoBuf[:0]
+				undoLog = bundle.getLockUndoLog(undo.regionId)
+				currRegion = undo.regionId
+			}
+			undoBuf = append(undoBuf, undo)
+		}
+		undoLog.appendUndoEntries(undoBuf)
+	}
+
+	var raftStates []*badger.Entry
 	if len(wb.entries) > 0 {
 		err := bundle.db.Update(func(txn *badger.Txn) error {
 			var err1 error
 			for _, entry := range wb.entries {
+				if IsRaftStateKey(entry.Key) {
+					raftStates = append(raftStates, entry)
+					continue
+				}
 				if len(entry.Value) == 0 {
 					err1 = txn.Delete(entry.Key)
 				} else {
@@ -176,7 +332,9 @@ func (wb *WriteBatch) WriteToKV(bundle *DBBundle) error {
 			return errors.WithStack(err)
 		}
 	}
+
 	if len(wb.lockEntries) > 0 {
+		bundle.memStoreMu.Lock()
 		for _, entry := range wb.lockEntries {
 			switch entry.UserMeta[0] {
 			case mvcc.LockUserMetaRollbackByte:
@@ -193,7 +351,31 @@ func (wb *WriteBatch) WriteToKV(bundle *DBBundle) error {
 				}
 			}
 		}
+		bundle.memStoreMu.Unlock()
 	}
+
+	if len(raftStates) > 0 {
+		err := bundle.db.Update(func(txn *badger.Txn) error {
+			var err1 error
+			for _, entry := range raftStates {
+				if err1 = txn.SetEntry(entry); err1 != nil {
+					return err1
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	for _, undo := range wb.undoEntries {
+		undoLog := bundle.getLockUndoLog(undo.regionId)
+		if atomic.LoadInt32(&undoLog.refCnt) == 0 {
+			undoLog.resetUndoEntries()
+		}
+	}
+
 	return nil
 }
 
@@ -237,10 +419,12 @@ func (wb *WriteBatch) MustWriteToRaft(db *badger.DB) {
 func (wb *WriteBatch) Reset() {
 	wb.entries = wb.entries[:0]
 	wb.lockEntries = wb.lockEntries[:0]
+	wb.undoEntries = wb.undoEntries[:0]
 	wb.size = 0
 	wb.safePoint = 0
 	wb.safePointLock = 0
 	wb.safePointSize = 0
+	wb.safePointUndo = 0
 }
 
 // Todo, the following code redundant to unistore/tikv/worker.go, just as a place holder now.
@@ -322,7 +506,7 @@ func deleteLocksInBatch(db *DBBundle, keys [][]byte, batchSize int) error {
 		keys = keys[batchSize:]
 		dbBatch := new(WriteBatch)
 		for _, key := range batchKeys {
-			dbBatch.DeleteLock(key)
+			dbBatch.DeleteLock(key, nil)
 		}
 		if err := dbBatch.WriteToKV(db); err != nil {
 			return err

--- a/tikv/raftstore/keys.go
+++ b/tikv/raftstore/keys.go
@@ -92,6 +92,10 @@ func SnapshotRaftStateKey(regionID uint64) []byte {
 	return makeRegionPrefix(regionID, SnapshotRaftStateSuffix)
 }
 
+func IsRaftStateKey(key []byte) bool {
+	return len(key) == 11 && key[0] == LocalPrefix && key[1] == RegionRaftPrefix
+}
+
 func decodeRegionMetaKey(key []byte) (uint64, byte, error) {
 	if len(RegionMetaMinKey)+8+1 != len(key) {
 		return 0, 0, errors.Errorf("invalid region meta key length for key %v", key)
@@ -173,4 +177,12 @@ func rawRegionKey(key []byte) []byte {
 	_, rawKey, err := codec.DecodeBytes(key, nil)
 	y.Assert(err == nil)
 	return rawKey
+}
+
+func rawDataStartKey(key []byte) []byte {
+	startKey := rawRegionKey(key)
+	if len(startKey) == 0 || startKey[0] == LocalPrefix {
+		startKey = []byte{LocalPrefix + 1}
+	}
+	return startKey
 }

--- a/tikv/raftstore/snap_manager.go
+++ b/tikv/raftstore/snap_manager.go
@@ -171,7 +171,7 @@ func (sm *SnapManager) GetTotalSnapSize() uint64 {
 	return uint64(atomic.LoadInt64(sm.snapSize))
 }
 
-func (sm *SnapManager) GetSnapshotForBuilding(key SnapKey, bundle *DBBundle) (Snapshot, error) {
+func (sm *SnapManager) GetSnapshotForBuilding(key SnapKey) (Snapshot, error) {
 	if sm.GetTotalSnapSize() > sm.MaxTotalSize {
 		err := sm.deleteOldIdleSnaps()
 		if err != nil {


### PR DESCRIPTION
1. Introduce the undo log to lockstore.
2. During snapshot use the same `Txn` to load `ApplyState`, `RegionState` and normal database entries.

PTAL @coocood 