### PR TITLE
fix mvcc and raft apply

### DIFF
--- a/tikv/dbreader/db_reader.go
+++ b/tikv/dbreader/db_reader.go
@@ -45,30 +45,12 @@ func (r *DBReader) Get(key []byte, startTS uint64) ([]byte, error) {
 		return nil, errors.Trace(err)
 	}
 	if err == badger.ErrKeyNotFound {
-		return r.getOld(key, startTS)
+		return nil, nil
 	}
 	if mvcc.DBUserMeta(item.UserMeta()).CommitTS() <= startTS {
 		return item.Value()
 	}
 	return r.getOld(key, startTS)
-}
-
-func (r *DBReader) HasNewerDelete(key []byte, startTS uint64) bool {
-	oldKey := mvcc.EncodeOldKey(key, startTS)
-	iter := r.GetIter()
-	iter.Seek(oldKey)
-	if !iter.ValidForPrefix(oldKey[:len(oldKey)-8]) {
-		return false
-	}
-	item := iter.Item()
-	nextCommitTs := mvcc.OldUserMeta(item.UserMeta()).NextCommitTS()
-	if nextCommitTs < r.safePoint {
-		// This entry is eligible for GC. Normally we will not see this version.
-		// But when the latest version is DELETE and it is GCed first,
-		// we may end up here, so we should ignore the obsolete version.
-		return false
-	}
-	return nextCommitTs > startTS
 }
 
 func (r *DBReader) getOld(key []byte, startTS uint64) ([]byte, error) {
@@ -174,7 +156,7 @@ func (r *DBReader) Scan(startKey, endKey []byte, limit int, startTS uint64, proc
 		}
 		var err error
 		if mvcc.DBUserMeta(item.UserMeta()).CommitTS() > startTS {
-			item, err = r.getOldItem(key, startTS)
+			item, err = r.getOldItem(mvcc.EncodeOldKey(key, startTS))
 			if err != nil {
 				continue
 			}
@@ -204,23 +186,16 @@ func (r *DBReader) Scan(startKey, endKey []byte, limit int, startTS uint64, proc
 	return nil
 }
 
-func (r *DBReader) getOldItem(key []byte, startTS uint64) (*badger.Item, error) {
-	oldKey := mvcc.EncodeOldKey(key, startTS)
+func (r *DBReader) getOldItem(oldKey []byte) (*badger.Item, error) {
 	oldIter := r.GetOldIter()
 	oldIter.Seek(oldKey)
 	if !oldIter.ValidForPrefix(oldKey[:len(oldKey)-8]) {
 		return nil, badger.ErrKeyNotFound
 	}
-	nextCommitTs := mvcc.OldUserMeta(oldIter.Item().UserMeta()).NextCommitTS()
-	if nextCommitTs < r.safePoint {
+	if mvcc.OldUserMeta(oldIter.Item().UserMeta()).NextCommitTS() < r.safePoint {
 		// Ignore the obsolete version.
 		return nil, badger.ErrKeyNotFound
 	}
-
-	if nextCommitTs <= startTS {
-		return nil, badger.ErrKeyNotFound
-	}
-
 	return oldIter.Item(), nil
 }
 
@@ -240,7 +215,7 @@ func (r *DBReader) ReverseScan(startKey, endKey []byte, limit int, startTS uint6
 		}
 		var err error
 		if mvcc.DBUserMeta(item.UserMeta()).CommitTS() > startTS {
-			item, err = r.getOldItem(key, startTS)
+			item, err = r.getOldItem(mvcc.EncodeOldKey(key, startTS))
 			if err != nil {
 				continue
 			}

--- a/tikv/mvcc.go
+++ b/tikv/mvcc.go
@@ -199,7 +199,7 @@ func (store *MVCCStore) Prewrite(reqCtx *requestCtx, mutations []*kvrpcpb.Mutati
 	var buf []byte
 	var enc rowcodec.Encoder
 	for i, m := range mutations {
-		oldMeta, oldVal, err := store.checkPrewriteInDB(reqCtx, txn, items[i], keys[i], startTS)
+		oldMeta, oldVal, err := store.checkPrewriteInDB(reqCtx, txn, items[i], startTS)
 		if err != nil {
 			anyError = true
 		}
@@ -274,11 +274,8 @@ func (store *MVCCStore) checkPrewriteInLockStore(
 // checkPrewrietInDB checks that there is no committed version greater than startTS or return write conflict error.
 // And it returns the old version if there is one.
 func (store *MVCCStore) checkPrewriteInDB(
-	req *requestCtx, txn *badger.Txn, item *badger.Item, key []byte, startTS uint64) (userMeta mvcc.DBUserMeta, val []byte, err error) {
+	req *requestCtx, txn *badger.Txn, item *badger.Item, startTS uint64) (userMeta mvcc.DBUserMeta, val []byte, err error) {
 	if item == nil {
-		if req.getDBReader().HasNewerDelete(key, startTS) {
-			return nil, nil, ErrRetryable("write conflict")
-		}
 		return nil, nil, nil
 	}
 	userMeta = mvcc.DBUserMeta(item.UserMeta())

--- a/tikv/raftstore/engine.go
+++ b/tikv/raftstore/engine.go
@@ -317,7 +317,7 @@ func (wb *WriteBatch) WriteToKV(bundle *DBBundle) error {
 					raftStates = append(raftStates, entry)
 					continue
 				}
-				if len(entry.Value) == 0 {
+				if len(entry.UserMeta) == 0 && len(entry.Value) == 0 {
 					err1 = txn.Delete(entry.Key)
 				} else {
 					err1 = txn.SetEntry(entry)

--- a/tikv/raftstore/read.go
+++ b/tikv/raftstore/read.go
@@ -98,5 +98,5 @@ func (c *leaderChecker) isExpired(ctx *kvrpcpb.Context, snapTime *time.Time) (bo
 	if appliedIndexTerm != term {
 		return true, nil
 	}
-	return lease.Inspect(snapTime) == LeaseState_Valid, nil
+	return lease.Inspect(snapTime) == LeaseState_Expired, nil
 }


### PR DESCRIPTION
Fix: 
* The `getOld` and `checkPrewrite` ignore the deleted entry, so they may return an incorrect old version or allow conflicted write.

* Prewrite of `LockKey` will delete the current value. 😂