### PR TITLE
add missing value in regionCtx.unmarshal

### DIFF
--- a/tikv/region.go
+++ b/tikv/region.go
@@ -117,6 +117,7 @@ func (ri *regionCtx) unmarshal(data []byte) error {
 	ri.latches = make(map[uint64]*sync.WaitGroup)
 	ri.startKey = ri.rawStartKey()
 	ri.endKey = ri.rawEndKey()
+	ri.regionEpoch = unsafe.Pointer(ri.meta.RegionEpoch)
 	ri.refCount.Add(1)
 	return nil
 }


### PR DESCRIPTION
Fix bugs in `StandAlongRegionManager` introduced by #209

PTAL @ngaut @coocood 