### PR TITLE
fix tableSplitChecker

### DIFF
--- a/tikv/raftstore/coprocessor_test.go
+++ b/tikv/raftstore/coprocessor_test.go
@@ -138,13 +138,6 @@ func TestLastKeyOfRegion(t *testing.T) {
 	engines := newTestEngines(t)
 	defer cleanUpTestEngineData(engines)
 
-	region := &metapb.Region{
-		Id: 1,
-		Peers: []*metapb.Peer{
-			new(metapb.Peer),
-		},
-	}
-
 	writeBatch := new(WriteBatch)
 	dataKeys := [2][]byte{}
 	padding := []byte("_r00000005")
@@ -159,9 +152,7 @@ func TestLastKeyOfRegion(t *testing.T) {
 	checkCases := func(startId, endId int64, want []byte) {
 		startTableKey := codec.EncodeInt(tablecodec.TablePrefix(), startId)
 		endTableKey := codec.EncodeInt(tablecodec.TablePrefix(), endId)
-		region.StartKey = startTableKey
-		region.EndKey = endTableKey
-		assert.Equal(t, lastKeyOfRegion(engines.kv.db, region), want)
+		assert.Equal(t, lastKeyOfRegion(engines.kv.db, startTableKey, endTableKey), want)
 	}
 
 	// ["", "") => t2_xx


### PR DESCRIPTION
-  Use non-encoded startKey and endKey to seek the last key of a region.
- `leftKey` or `rightKey` in `isSameTable` may have length equal to `tablecodec.TableSplitKeyLen`