### PR TITLE
rowcodec: encode row int/uint as varint/varuint when back to old row

### DIFF
--- a/rowcodec/common.go
+++ b/rowcodec/common.go
@@ -23,6 +23,7 @@ const (
 	IntFlag          byte = 3
 	UintFlag         byte = 4
 	VarintFlag       byte = 8
+	VaruintFlag      byte = 9
 )
 
 // row is the struct type used to access the a row.

--- a/rowcodec/encoder.go
+++ b/rowcodec/encoder.go
@@ -337,11 +337,11 @@ func RowToOldRow(rowData, buf []byte) ([]byte, error) {
 				buf = append(buf, CompactBytesFlag)
 				buf = codec.EncodeCompactBytes(buf, val)
 			case IntFlag:
-				buf = append(buf, IntFlag)
-				buf = codec.EncodeInt(buf, decodeInt(val))
+				buf = append(buf, VarintFlag)
+				buf = codec.EncodeVarint(buf, decodeInt(val))
 			case UintFlag:
-				buf = append(buf, UintFlag)
-				buf = codec.EncodeUint(buf, decodeUint(val))
+				buf = append(buf, VaruintFlag)
+				buf = codec.EncodeUvarint(buf, decodeUint(val))
 			default:
 				buf = append(buf, r.valFlags[i])
 				buf = append(buf, val...)


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Current union store encodes row data as new row-format:

https://github.com/pingcap/tidb/blob/master/docs/design/2018-07-19-row-format.md

and it changes int/uint encoding:

>For integer values, we store {byte, uint16, uint32, uint64} instead of varint for fast decoding. The type can be inferred by the column value size. The string value is stored as it is. Other types are encoded in the old way without the first type flag byte.

this introduces incompatibility problem if encode value need be used in the query.

for example this script:

```
drop table if exists t1;
create table t1(a time);
insert into t1 values (1), (2), (3);
analyze table t1;
explain select * from t1 where a = 1;
```

explain can not get an accurate count for condition `a=1`

value `1` be encoded as int and `RowToOldRow` as int, and `1` with `IntFlag` value will be put into cmsketch.

and tidb will use `1` with `VarintFlag` to query cmsketch and found nothing.

and we cannot make it compatibility in TiDB side: because when a TiKV upgrade from old-version,  there are some row in new-format and some others in old one, value `1` can be stats as different two value in cmsketch and it also same to the histogram.

### What is changed and how it works?

it's better we just change row-format, and keep using old datum-format, for row-value better keep it in varint?

### Test
 this can make `explain select * from t1 where a = 1;` get right result.

@lamxTyler

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ngaut/unistore/237)
<!-- Reviewable:end -->
