### PR TITLE
rowcodec: fix bug in `RowToOldRow` when row is large

### DIFF
--- a/rowcodec/encoder.go
+++ b/rowcodec/encoder.go
@@ -329,55 +329,40 @@ func RowToOldRow(rowData, buf []byte) ([]byte, error) {
 	}
 	if !r.large {
 		for i, colID := range r.colIDs {
-			buf = append(buf, VarintFlag)
-			buf = codec.EncodeVarint(buf, int64(colID))
-			if i < int(r.numNotNullCols) {
-				val := r.getData(i)
-				switch r.valFlags[i] {
-				case BytesFlag:
-					buf = append(buf, CompactBytesFlag)
-					buf = codec.EncodeCompactBytes(buf, val)
-				case IntFlag:
-					buf = append(buf, VarintFlag)
-					buf = codec.EncodeVarint(buf, decodeInt(val))
-				case UintFlag:
-					buf = append(buf, VaruintFlag)
-					buf = codec.EncodeUvarint(buf, decodeUint(val))
-				default:
-					buf = append(buf, r.valFlags[i])
-					buf = append(buf, val...)
-				}
-			} else {
-				buf = append(buf, NilFlag)
-			}
+			buf = encodeOldOne(&r, buf, i, int64(colID))
 		}
 	} else {
 		for i, colID := range r.colIDs32 {
-			buf = append(buf, VarintFlag)
-			buf = codec.EncodeVarint(buf, int64(colID))
-			if i < int(r.numNotNullCols) {
-				val := r.getData(i)
-				switch r.valFlags[i] {
-				case BytesFlag:
-					buf = append(buf, CompactBytesFlag)
-					buf = codec.EncodeCompactBytes(buf, val)
-				case IntFlag:
-					buf = append(buf, VarintFlag)
-					buf = codec.EncodeVarint(buf, decodeInt(val))
-				case UintFlag:
-					buf = append(buf, VaruintFlag)
-					buf = codec.EncodeUvarint(buf, decodeUint(val))
-				default:
-					buf = append(buf, r.valFlags[i])
-					buf = append(buf, val...)
-				}
-			} else {
-				buf = append(buf, NilFlag)
-			}
+			buf = encodeOldOne(&r, buf, i, int64(colID))
 		}
 	}
 	if len(buf) == 0 {
 		buf = append(buf, NilFlag)
 	}
 	return buf, nil
+}
+
+func encodeOldOne(r *row, buf []byte, i int, colID int64) []byte {
+	buf = append(buf, VarintFlag)
+	buf = codec.EncodeVarint(buf, colID)
+	if i < int(r.numNotNullCols) {
+		val := r.getData(i)
+		switch r.valFlags[i] {
+		case BytesFlag:
+			buf = append(buf, CompactBytesFlag)
+			buf = codec.EncodeCompactBytes(buf, val)
+		case IntFlag:
+			buf = append(buf, VarintFlag)
+			buf = codec.EncodeVarint(buf, decodeInt(val))
+		case UintFlag:
+			buf = append(buf, VaruintFlag)
+			buf = codec.EncodeUvarint(buf, decodeUint(val))
+		default:
+			buf = append(buf, r.valFlags[i])
+			buf = append(buf, val...)
+		}
+	} else {
+		buf = append(buf, NilFlag)
+	}
+	return buf
 }


### PR DESCRIPTION
when `r.large == true`,  `colIDs` will in `r.colIDs32` and `RowToOldRow` will return empty result now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ngaut/unistore/241)
<!-- Reviewable:end -->
