### PR TITLE
support distributed dead lock detection

### DIFF
--- a/tikv/deadlock.go
+++ b/tikv/deadlock.go
@@ -1,0 +1,217 @@
+package tikv
+
+import (
+	"context"
+	"google.golang.org/grpc"
+	"sync/atomic"
+	"time"
+
+	"github.com/ngaut/log"
+	"github.com/ngaut/unistore/pd"
+	"github.com/ngaut/unistore/util/lockwaiter"
+	deadlockPb "github.com/pingcap/kvproto/pkg/deadlock"
+	"github.com/pingcap/kvproto/pkg/metapb"
+)
+
+// Follower will send detection rpc to Leader
+const (
+	Follower = iota
+	Leader
+)
+
+// DeadlockDetector is a util used for distributed deadlock detection
+type DeadlockDetector struct {
+	detector  *Detector
+	pdClient  pd.Client
+	storeMeta *metapb.Store
+	sendCh    chan *deadlockPb.DeadlockRequest
+	waitMgr   *lockwaiter.Manager
+	streamCli deadlockPb.Deadlock_DetectClient
+
+	// these fields used by multiple thread
+	role int32
+}
+
+// refreshFirstRegionLeader will send request to pd to find out the
+// current leader node for the first region
+func (dt *DeadlockDetector) refreshFirstRegionLeader() (string, error) {
+	// find first region from pd, get the first region leader
+	ctx := context.Background()
+	_, leaderPeer, err := dt.pdClient.GetRegion(ctx, []byte{})
+	if err != nil {
+		log.Errorf("get first region failed, err: %v", err)
+		return "", err
+	}
+	leaderStoreMeta, err := dt.pdClient.GetStore(ctx, leaderPeer.GetStoreId())
+	if err != nil {
+		log.Errorf("get store=%d failed, err=%v", leaderPeer.GetStoreId(), err)
+		return "", err
+	}
+	log.Warnf("refreshFirstRegionLeader leader_peer=%v addr=%s", leaderPeer, leaderStoreMeta.GetAddress())
+	return leaderStoreMeta.GetAddress(), nil
+}
+
+// rebuildStreamClient builds connection to the first region leader,
+// it's not thread safe and should be called only by `DeadlockDetector.Start` or `DeadlockDetector.SendReqLoop`
+func (dt *DeadlockDetector) rebuildStreamClient() (string, error) {
+	leaderArr, err := dt.refreshFirstRegionLeader()
+	if err != nil {
+		return "", err
+	}
+	cc, err := grpc.Dial(leaderArr, grpc.WithInsecure())
+	if err != nil {
+		return "", err
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	stream, err := deadlockPb.NewDeadlockClient(cc).Detect(ctx)
+	if err != nil {
+		cancel()
+		return "", err
+	}
+	dt.streamCli = stream
+	go dt.recvLoop(dt.streamCli)
+	return leaderArr, nil
+}
+
+// NewDeadlockDetector will create a new detector util, entryTTL is used for
+// recycling the lock wait edge in detector wait wap. chSize is the pending
+// detection sending task size(used on non leader node)
+func NewDeadlockDetector(waiterMgr *lockwaiter.Manager) *DeadlockDetector {
+	chSize := 1000
+	entryTTL := time.Duration(3 * time.Second)
+	urgentSize := uint64(100000)
+	exipreInterval := 3600 * time.Second
+	newDetector := &DeadlockDetector{
+		detector: NewDetector(entryTTL, urgentSize, exipreInterval),
+		sendCh:   make(chan *deadlockPb.DeadlockRequest, chSize),
+		waitMgr:  waiterMgr,
+	}
+	return newDetector
+}
+
+// Start starts the detection `send`, `recv` and `entry recycle` loop
+func (dt *DeadlockDetector) Start() {
+	go dt.sendReqLoop()
+}
+
+// sendReqLoop will send detection request to leader, stream connection will be rebuilt and
+// a new recv goroutine using the same stream client will be created
+func (dt *DeadlockDetector) sendReqLoop() {
+	var (
+		err        error
+		rebuildErr error
+		req        *deadlockPb.DeadlockRequest
+		leaderAddr string
+	)
+	for {
+		if dt.streamCli == nil {
+			leaderAddr, rebuildErr = dt.rebuildStreamClient()
+			if rebuildErr != nil {
+				log.Errorf("rebuild connection to first region failed, err=%v", rebuildErr)
+				time.Sleep(3 * time.Second)
+				continue
+			}
+			log.Infof("rebuild stream connection to leader peer success, leaderAddr=%v", leaderAddr)
+		}
+		req = <-dt.sendCh
+		err = dt.streamCli.Send(req)
+		if err != nil {
+			log.Warnf("send req to addr=%v failed, err=%v, invalid current stream and try to rebuild connection",
+				leaderAddr, err)
+			dt.streamCli = nil
+		}
+	}
+}
+
+// recvLoop tries to recv response(current only deadlock error) from leader, break loop if errors happen
+func (dt *DeadlockDetector) recvLoop(streamCli deadlockPb.Deadlock_DetectClient) {
+	var (
+		err  error
+		resp *deadlockPb.DeadlockResponse
+	)
+	for {
+		resp, err = streamCli.Recv()
+		if err != nil {
+			log.Warnf("recv from failed, err=%v, stop receive", err)
+			break
+		}
+		// here only detection request will get response from leader
+		dt.waitMgr.WakeUpForDeadlock(resp)
+	}
+}
+
+func (dt *DeadlockDetector) sendReqToLeader(req *deadlockPb.DeadlockRequest) {
+	dt.sendCh <- req
+}
+
+func (dt *DeadlockDetector) handleRemoteTask(requestType deadlockPb.DeadlockRequestType,
+	txnTs uint64, waitForTxnTs uint64, keyHash uint64) {
+	detectReq := &deadlockPb.DeadlockRequest{}
+	detectReq.Tp = requestType
+	detectReq.Entry.Txn = txnTs
+	detectReq.Entry.WaitForTxn = waitForTxnTs
+	detectReq.Entry.KeyHash = keyHash
+	dt.sendReqToLeader(detectReq)
+}
+
+func (dt *DeadlockDetector) isLeader() bool {
+	return atomic.LoadInt32(&dt.role) == Leader
+}
+
+func (dt *DeadlockDetector) ChangeRole(newRole int32) {
+	atomic.StoreInt32(&dt.role, newRole)
+}
+
+// user interfaces
+// Cleanup processes cleaup task on local detector
+func (dt *DeadlockDetector) CleanUp(startTs uint64) {
+	if dt.isLeader() {
+		dt.detector.CleanUp(startTs)
+	} else {
+		dt.handleRemoteTask(deadlockPb.DeadlockRequestType_CleanUp, startTs, 0, 0)
+	}
+}
+
+// CleanUpWaitFor cleans up the specific wait edge in detector's wait map
+func (dt *DeadlockDetector) CleanUpWaitFor(txnTs, waitForTxn, keyHash uint64) {
+	if dt.isLeader() {
+		dt.detector.CleanUpWaitFor(txnTs, waitForTxn, keyHash)
+	} else {
+		dt.handleRemoteTask(deadlockPb.DeadlockRequestType_CleanUpWaitFor, txnTs, waitForTxn, keyHash)
+	}
+}
+
+// Detect will process the detection request on local detector
+func (dt *DeadlockDetector) Detect(txnTs uint64, waitForTxnTs uint64, keyHash uint64) error {
+	err := dt.detector.Detect(txnTs, waitForTxnTs, keyHash)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// convertErrToResp converts `ErrDeadlock` to `DeadlockResponse` proto type
+func convertErrToResp(errDeadlock *ErrDeadlock, txnTs, waitForTxnTs, keyHash uint64) *deadlockPb.DeadlockResponse {
+	entry := deadlockPb.WaitForEntry{}
+	entry.Txn = txnTs
+	entry.WaitForTxn = waitForTxnTs
+	entry.KeyHash = keyHash
+	resp := &deadlockPb.DeadlockResponse{}
+	resp.Entry = entry
+	resp.DeadlockKeyHash = errDeadlock.DeadlockKeyHash
+	return resp
+}
+
+// DetectRemote post the detection request to local deadlock detector or remote first region leader,
+// the caller should use `waiter.ch` to receive possible deadlock response
+func (dt *DeadlockDetector) DetectRemote(txnTs uint64, waitForTxnTs uint64, keyHash uint64) {
+	if dt.isLeader() {
+		err := dt.Detect(txnTs, waitForTxnTs, keyHash)
+		if err != nil {
+			resp := convertErrToResp(err.(*ErrDeadlock), txnTs, waitForTxnTs, keyHash)
+			dt.waitMgr.WakeUpForDeadlock(resp)
+		}
+	} else {
+		dt.handleRemoteTask(deadlockPb.DeadlockRequestType_Detect, txnTs, waitForTxnTs, keyHash)
+	}
+}

--- a/tikv/detector.go
+++ b/tikv/detector.go
@@ -1,0 +1,168 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package tikv
+
+import (
+	"container/list"
+	"sync"
+	"time"
+
+	"github.com/ngaut/log"
+)
+
+// Detector detects deadlock.
+type Detector struct {
+	waitForMap       map[uint64]*txnList
+	lock             sync.Mutex
+	entryTTL         time.Duration
+	totalSize        uint64
+	lastActiveExpire time.Time
+	urgentSize       uint64
+	expireInterval   time.Duration
+}
+
+type txnList struct {
+	//txns []txnKeyHashPair
+	txns *list.List
+}
+
+type txnKeyHashPair struct {
+	txn          uint64
+	keyHash      uint64
+	registerTime time.Time
+}
+
+func (p *txnKeyHashPair) isExpired(ttl time.Duration, nowTime time.Time) bool {
+	if p.registerTime.Add(ttl).Before(nowTime) {
+		return true
+	}
+	return false
+}
+
+// NewDetector creates a new Detector.
+func NewDetector(ttl time.Duration, urgentSize uint64, expireInterval time.Duration) *Detector {
+	return &Detector{
+		waitForMap:       map[uint64]*txnList{},
+		entryTTL:         ttl,
+		lastActiveExpire: time.Now(),
+		urgentSize:       urgentSize,
+		expireInterval:   expireInterval,
+	}
+}
+
+// Detect detects deadlock for the sourceTxn on a locked key.
+func (d *Detector) Detect(sourceTxn, waitForTxn, keyHash uint64) *ErrDeadlock {
+	d.lock.Lock()
+	d.activeExpire()
+	err := d.doDetect(sourceTxn, waitForTxn)
+	if err == nil {
+		d.register(sourceTxn, waitForTxn, keyHash)
+	}
+	d.lock.Unlock()
+	return err
+}
+
+func (d *Detector) doDetect(sourceTxn, waitForTxn uint64) *ErrDeadlock {
+	val := d.waitForMap[waitForTxn]
+	if val == nil {
+		return nil
+	}
+	for cur := val.txns.Front(); cur != nil; cur = cur.Next() {
+		keyHashPair := cur.Value.(*txnKeyHashPair)
+		if keyHashPair.txn == sourceTxn {
+			return &ErrDeadlock{DeadlockKeyHash: keyHashPair.keyHash}
+		}
+		if err := d.doDetect(sourceTxn, keyHashPair.txn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *Detector) register(sourceTxn, waitForTxn, keyHash uint64) {
+	val := d.waitForMap[sourceTxn]
+	pair := txnKeyHashPair{txn: waitForTxn, keyHash: keyHash, registerTime: time.Now()}
+	if val == nil {
+		newList := &txnList{txns: list.New()}
+		newList.txns.PushBack(&pair)
+		d.waitForMap[sourceTxn] = newList
+		d.totalSize++
+		return
+	}
+	for cur := val.txns.Front(); cur != nil; cur = cur.Next() {
+		valuePair := cur.Value.(*txnKeyHashPair)
+		if valuePair.txn == waitForTxn && valuePair.keyHash == keyHash {
+			return
+		}
+	}
+	val.txns.PushBack(&pair)
+	d.totalSize++
+}
+
+// CleanUp removes the wait for entry for the transaction.
+func (d *Detector) CleanUp(txn uint64) {
+	d.lock.Lock()
+	if l, ok := d.waitForMap[txn]; ok {
+		d.totalSize -= uint64(l.txns.Len())
+	}
+	delete(d.waitForMap, txn)
+	d.lock.Unlock()
+}
+
+// CleanUpWaitFor removes a key in the wait for entry for the transaction.
+func (d *Detector) CleanUpWaitFor(txn, waitForTxn, keyHash uint64) {
+	d.lock.Lock()
+	l := d.waitForMap[txn]
+	if l != nil {
+		var nextVal *list.Element
+		for cur := l.txns.Front(); cur != nil; cur = nextVal {
+			nextVal = cur.Next()
+			valuePair := cur.Value.(*txnKeyHashPair)
+			if valuePair.txn == waitForTxn && valuePair.keyHash == keyHash {
+				l.txns.Remove(cur)
+				d.totalSize--
+				break
+			}
+		}
+		if l.txns.Len() == 0 {
+			delete(d.waitForMap, txn)
+		}
+	}
+	d.lock.Unlock()
+
+}
+
+// activeExpire removes expired entries, should be called under d.lock protection
+func (d *Detector) activeExpire() {
+	nowTime := time.Now()
+	if nowTime.Sub(d.lastActiveExpire) > d.expireInterval ||
+		d.totalSize >= d.urgentSize {
+		log.Infof("detector will do activeExpire, current size=%v", d.totalSize)
+		for txn, l := range d.waitForMap {
+			var nextVal *list.Element
+			for cur := l.txns.Front(); cur != nil; cur = nextVal {
+				nextVal = cur.Next()
+				valuePair := cur.Value.(*txnKeyHashPair)
+				if valuePair.isExpired(d.entryTTL, nowTime) {
+					l.txns.Remove(cur)
+					d.totalSize--
+				}
+			}
+			if l.txns.Len() == 0 {
+				delete(d.waitForMap, txn)
+			}
+		}
+		d.lastActiveExpire = nowTime
+		log.Infof("detector activeExpire finished, current size=%v", d.totalSize)
+	}
+}

--- a/tikv/detector.go
+++ b/tikv/detector.go
@@ -156,7 +156,7 @@ func (d *Detector) CleanUpWaitFor(txn, waitForTxn, keyHash uint64) {
 
 // activeExpire removes expired entries, should be called under d.lock protection
 func (d *Detector) activeExpire(nowTime time.Time) {
-	if nowTime.Sub(d.lastActiveExpire) > d.expireInterval ||
+	if nowTime.Sub(d.lastActiveExpire) > d.expireInterval &&
 		d.totalSize >= d.urgentSize {
 		log.Infof("detector will do activeExpire, current size=%v", d.totalSize)
 		for txn, l := range d.waitForMap {

--- a/tikv/detector_test.go
+++ b/tikv/detector_test.go
@@ -1,0 +1,84 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package tikv
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/pingcap/check"
+)
+
+func TestT(t *testing.T) {
+	TestingT(t)
+}
+
+var _ = Suite(&testDeadlockSuite{})
+
+type testDeadlockSuite struct{}
+
+func (s *testDeadlockSuite) TestDeadlock(c *C) {
+	ttl := time.Duration(50 * time.Millisecond)
+	expireInterval := time.Duration(100 * time.Millisecond)
+	urgentSize := uint64(1)
+	detector := NewDetector(ttl, urgentSize, expireInterval)
+	err := detector.Detect(1, 2, 100)
+	c.Assert(err, IsNil)
+	c.Assert(detector.totalSize, Equals, uint64(1))
+	err = detector.Detect(2, 3, 200)
+	c.Assert(err, IsNil)
+	c.Assert(detector.totalSize, Equals, uint64(2))
+	err = detector.Detect(3, 1, 300)
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, fmt.Sprintf("deadlock"))
+	c.Assert(detector.totalSize, Equals, uint64(2))
+	detector.CleanUp(2)
+	list2 := detector.waitForMap[2]
+	c.Assert(list2, IsNil)
+	c.Assert(detector.totalSize, Equals, uint64(1))
+
+	// After cycle is broken, no deadlock now.
+	err = detector.Detect(3, 1, 300)
+	c.Assert(err, IsNil)
+	list3 := detector.waitForMap[3]
+	c.Assert(list3.txns.Len(), Equals, 1)
+	c.Assert(detector.totalSize, Equals, uint64(2))
+
+	// Different keyHash grows the list.
+	err = detector.Detect(3, 1, 400)
+	c.Assert(err, IsNil)
+	c.Assert(list3.txns.Len(), Equals, 2)
+	c.Assert(detector.totalSize, Equals, uint64(3))
+
+	// Same waitFor and key hash doesn't grow the list.
+	err = detector.Detect(3, 1, 400)
+	c.Assert(err, IsNil)
+	c.Assert(list3.txns.Len(), Equals, 2)
+	c.Assert(detector.totalSize, Equals, uint64(3))
+
+	detector.CleanUpWaitFor(3, 1, 300)
+	c.Assert(list3.txns.Len(), Equals, 1)
+	c.Assert(detector.totalSize, Equals, uint64(2))
+	detector.CleanUpWaitFor(3, 1, 400)
+	c.Assert(detector.totalSize, Equals, uint64(1))
+	list3 = detector.waitForMap[3]
+	c.Assert(list3, IsNil)
+
+	// after 100ms, all entries expired, detect non exist edges
+	time.Sleep(100 * time.Millisecond)
+	err = detector.Detect(0, 0, 0)
+	c.Assert(err, IsNil)
+	c.Assert(detector.totalSize, Equals, uint64(1))
+	c.Assert(len(detector.waitForMap), Equals, 1)
+}

--- a/tikv/detector_test.go
+++ b/tikv/detector_test.go
@@ -77,7 +77,15 @@ func (s *testDeadlockSuite) TestDeadlock(c *C) {
 
 	// after 100ms, all entries expired, detect non exist edges
 	time.Sleep(100 * time.Millisecond)
-	err = detector.Detect(0, 0, 0)
+	err = detector.Detect(100, 200, 100)
+	c.Assert(err, IsNil)
+	c.Assert(detector.totalSize, Equals, uint64(1))
+	c.Assert(len(detector.waitForMap), Equals, 1)
+
+	// expired entry should not report deadlock, detect will remove this entry
+	// not dependent on expire check interval
+	time.Sleep(60 * time.Millisecond)
+	err = detector.Detect(200, 100, 200)
 	c.Assert(err, IsNil)
 	c.Assert(detector.totalSize, Equals, uint64(1))
 	c.Assert(len(detector.waitForMap), Equals, 1)

--- a/tikv/errors.go
+++ b/tikv/errors.go
@@ -47,6 +47,7 @@ func (e ErrKeyAlreadyExists) Error() string {
 	return "key already exists"
 }
 
+// ErrDeadlock is returned when deadlock is detected.
 type ErrDeadlock struct {
 	LockKey         []byte
 	LockTS          uint64

--- a/tikv/mvcc.go
+++ b/tikv/mvcc.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ngaut/unistore/rowcodec"
 	"github.com/ngaut/unistore/tikv/dbreader"
 	"github.com/ngaut/unistore/tikv/mvcc"
-	"github.com/ngaut/unistore/tikv/raftstore"
 	"github.com/ngaut/unistore/util/lockwaiter"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/store/tikv/oracle"
@@ -865,7 +864,6 @@ func (store *MVCCStore) StartDeadlockDetection(ctx context.Context, pdClient pd.
 		store.DeadlockDetector.ChangeRole(Leader)
 	} else {
 		store.DeadlockDetector.pdClient = pdClient
-		store.DeadlockDetector.storeMeta = innerSrv.(*raftstore.RaftInnerServer).GetStoreMeta()
 		store.DeadlockDetector.Start()
 		log.Infof("raft store startDeadlockDetection finished started as role=%v", store.DeadlockDetector.role)
 	}

--- a/tikv/raftstore/peer.go
+++ b/tikv/raftstore/peer.go
@@ -719,6 +719,7 @@ func (p *Peer) OnRoleChanged(ctx *PollContext, ready *raft.Ready) {
 		} else if ss.RaftState == raft.StateFollower {
 			p.leaderLease.Expire()
 		}
+		ctx.peerEventObserver.OnRoleChange(p.getEventContext().RegionId, ss.RaftState)
 	}
 }
 

--- a/tikv/region.go
+++ b/tikv/region.go
@@ -262,10 +262,10 @@ type RaftRegionManager struct {
 	regionManager
 	router   *raftstore.RaftstoreRouter
 	eventCh  chan interface{}
-	detector *DeadlockDetector
+	detector *DetectorServer
 }
 
-func NewRaftRegionManager(store *metapb.Store, router *raftstore.RaftstoreRouter, detector *DeadlockDetector) *RaftRegionManager {
+func NewRaftRegionManager(store *metapb.Store, router *raftstore.RaftstoreRouter, detector *DetectorServer) *RaftRegionManager {
 	m := &RaftRegionManager{
 		router: router,
 		regionManager: regionManager{

--- a/unistore-server/main.go
+++ b/unistore-server/main.go
@@ -184,7 +184,7 @@ func setupRaftInnerServer(bundle *mvcc.DBBundle, safePoint *tikv.SafePoint, pdCl
 	router := innerServer.GetRaftstoreRouter()
 	storeMeta := innerServer.GetStoreMeta()
 	store := tikv.NewMVCCStore(bundle, dbPath, safePoint, raftstore.NewDBWriter(router))
-	rm := tikv.NewRaftRegionManager(storeMeta, router, store)
+	rm := tikv.NewRaftRegionManager(storeMeta, router, store.DeadlockDetector)
 	innerServer.SetPeerEventObserver(rm)
 
 	if err := innerServer.Start(pdClient); err != nil {

--- a/unistore-server/main.go
+++ b/unistore-server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/binary"
 	"flag"
 	"net"
@@ -23,6 +24,7 @@ import (
 	"github.com/ngaut/unistore/tikv"
 	"github.com/ngaut/unistore/tikv/mvcc"
 	"github.com/ngaut/unistore/tikv/raftstore"
+	"github.com/pingcap/kvproto/pkg/deadlock"
 	"github.com/pingcap/kvproto/pkg/tikvpb"
 	"google.golang.org/grpc"
 )
@@ -59,6 +61,7 @@ func main() {
 	log.SetLevelByString(conf.LogLevel)
 	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds | log.Lshortfile)
 	safePoint := &tikv.SafePoint{}
+	log.Infof("conf %v", conf)
 	db := createDB(subPathKV, safePoint, &conf.Engine)
 	bundle := &mvcc.DBBundle{
 		DB:            db,
@@ -81,6 +84,10 @@ func main() {
 	} else {
 		innerServer, store, regionManager = setupStandAlongInnerServer(bundle, safePoint, pdClient, conf)
 	}
+	err = store.StartDeadlockDetection(context.Background(), pdClient, innerServer, conf.Raft)
+	if err != nil {
+		log.Fatal("StartDeadlockDetection error=%v", err)
+	}
 
 	tikvServer := tikv.NewServer(regionManager, store, innerServer)
 
@@ -92,6 +99,7 @@ func main() {
 	tikvpb.RegisterTikvServer(grpcServer, tikvServer)
 	listenAddr := conf.StoreAddr[strings.IndexByte(conf.StoreAddr, ':'):]
 	l, err := net.Listen("tcp", listenAddr)
+	deadlock.RegisterDeadlockServer(grpcServer, tikvServer)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -176,7 +184,7 @@ func setupRaftInnerServer(bundle *mvcc.DBBundle, safePoint *tikv.SafePoint, pdCl
 	router := innerServer.GetRaftstoreRouter()
 	storeMeta := innerServer.GetStoreMeta()
 	store := tikv.NewMVCCStore(bundle, dbPath, safePoint, raftstore.NewDBWriter(router))
-	rm := tikv.NewRaftRegionManager(storeMeta, router)
+	rm := tikv.NewRaftRegionManager(storeMeta, router, store)
 	innerServer.SetPeerEventObserver(rm)
 
 	if err := innerServer.Start(pdClient); err != nil {

--- a/unistore-server/main.go
+++ b/unistore-server/main.go
@@ -183,8 +183,8 @@ func setupRaftInnerServer(bundle *mvcc.DBBundle, safePoint *tikv.SafePoint, pdCl
 	innerServer.Setup(pdClient)
 	router := innerServer.GetRaftstoreRouter()
 	storeMeta := innerServer.GetStoreMeta()
-	store := tikv.NewMVCCStore(bundle, dbPath, safePoint, raftstore.NewDBWriter(router))
-	rm := tikv.NewRaftRegionManager(storeMeta, router, store.DeadlockDetector)
+	store := tikv.NewMVCCStore(bundle, dbPath, safePoint, raftstore.NewDBWriter(router), pdClient)
+	rm := tikv.NewRaftRegionManager(storeMeta, router, store.DeadlockDetectSvr)
 	innerServer.SetPeerEventObserver(rm)
 
 	if err := innerServer.Start(pdClient); err != nil {
@@ -203,7 +203,7 @@ func setupStandAlongInnerServer(bundle *mvcc.DBBundle, safePoint *tikv.SafePoint
 
 	innerServer := tikv.NewStandAlongInnerServer(bundle)
 	innerServer.Setup(pdClient)
-	store := tikv.NewMVCCStore(bundle, conf.Engine.DBPath, safePoint, tikv.NewDBWriter(bundle, safePoint))
+	store := tikv.NewMVCCStore(bundle, conf.Engine.DBPath, safePoint, tikv.NewDBWriter(bundle, safePoint), pdClient)
 	rm := tikv.NewStandAloneRegionManager(bundle.DB, regionOpts, pdClient)
 
 	if err := innerServer.Start(pdClient); err != nil {

--- a/util/lockwaiter/lockwaiter.go
+++ b/util/lockwaiter/lockwaiter.go
@@ -146,6 +146,9 @@ func (lw *Manager) CleanUp(w *Waiter) {
 	q := lw.waitingQueues[w.LockTS]
 	if q != nil {
 		q.removeWaiter(w)
+		if len(q.waiters) == 0 {
+			delete(lw.waitingQueues, w.LockTS)
+		}
 	}
 	lw.mu.Unlock()
 }

--- a/util/lockwaiter/lockwaiter.go
+++ b/util/lockwaiter/lockwaiter.go
@@ -21,13 +21,13 @@ func NewManager() *Manager {
 }
 
 type queue struct {
-	mu      sync.Mutex
 	waiters []*Waiter
 }
 
+// getReadyWaiters returns the ready waiters array, and left waiter size in this queue,
+// it should be used under map lock protection
 func (q *queue) getReadyWaiters(keyHashes []uint64) (readyWaiters []*Waiter, remainSize int) {
 	readyWaiters = make([]*Waiter, 0, 8)
-	q.mu.Lock()
 	remainedWaiters := q.waiters[:0]
 	for _, w := range q.waiters {
 		if w.inKeys(keyHashes) {
@@ -38,24 +38,23 @@ func (q *queue) getReadyWaiters(keyHashes []uint64) (readyWaiters []*Waiter, rem
 	}
 	remainSize = len(remainedWaiters)
 	q.waiters = remainedWaiters
-	q.mu.Unlock()
 	return
 }
 
+// removeWaiter removes the correspond waiter from pending array
+// it should be used under map lock protection
 func (q *queue) removeWaiter(w *Waiter) {
-	q.mu.Lock()
 	for i, waiter := range q.waiters {
 		if waiter == w {
 			q.waiters = append(q.waiters[:i], q.waiters[i+1:]...)
 			break
 		}
 	}
-	q.mu.Unlock()
 }
 
 type Waiter struct {
 	timeout time.Duration
-	ch      chan Result
+	ch      chan WaitResult
 	startTS uint64
 	LockTS  uint64
 	KeyHash uint64
@@ -63,7 +62,7 @@ type Waiter struct {
 
 type Position int
 
-type Result struct {
+type WaitResult struct {
 	Position     Position
 	CommitTS     uint64
 	DeadlockResp *deadlock.DeadlockResponse
@@ -71,10 +70,10 @@ type Result struct {
 
 const WaitTimeout Position = -1
 
-func (w *Waiter) Wait() Result {
+func (w *Waiter) Wait() WaitResult {
 	select {
 	case <-time.After(w.timeout):
-		return Result{Position: WaitTimeout}
+		return WaitResult{Position: WaitTimeout}
 	case result := <-w.ch:
 		return result
 	}
@@ -97,7 +96,7 @@ func (lw *Manager) NewWaiter(startTS, lockTS, keyHash uint64, timeout time.Durat
 	q.waiters = make([]*Waiter, 0, 8)
 	waiter := &Waiter{
 		timeout: timeout,
-		ch:      make(chan Result, 1),
+		ch:      make(chan WaitResult, 1),
 		startTS: startTS,
 		LockTS:  lockTS,
 		KeyHash: keyHash,
@@ -115,26 +114,29 @@ func (lw *Manager) NewWaiter(startTS, lockTS, keyHash uint64, timeout time.Durat
 
 // WakeUp wakes up waiters that waiting on the transaction.
 func (lw *Manager) WakeUp(txn, commitTS uint64, keyHashes []uint64) {
+	var (
+		waiters    []*Waiter
+		remainSize int
+	)
 	lw.mu.Lock()
 	q := lw.waitingQueues[txn]
-	lw.mu.Unlock()
 	if q != nil {
 		sort.Slice(keyHashes, func(i, j int) bool {
 			return keyHashes[i] < keyHashes[j]
 		})
-		waiters, remainSize := q.getReadyWaiters(keyHashes)
+		waiters, remainSize = q.getReadyWaiters(keyHashes)
 		if remainSize == 0 {
-			lw.mu.Lock()
 			delete(lw.waitingQueues, txn)
-			lw.mu.Unlock()
 		}
-		sort.Slice(waiters, func(i, j int) bool {
-			return waiters[i].startTS < waiters[j].startTS
-		})
+	}
+	lw.mu.Unlock()
+
+	// wake up waiters
+	if len(waiters) > 0 {
 		for i, w := range waiters {
-			w.ch <- Result{Position: Position(i), CommitTS: commitTS}
+			w.ch <- WaitResult{Position: Position(i), CommitTS: commitTS}
 		}
-		log.Info("wakeup", len(waiters), "txns blocked by", txn, keyHashes)
+		log.Info("wakeup", len(waiters), "txns blocked by txn", txn, " keyHashes=", keyHashes)
 	}
 }
 
@@ -142,29 +144,39 @@ func (lw *Manager) WakeUp(txn, commitTS uint64, keyHashes []uint64) {
 func (lw *Manager) CleanUp(w *Waiter) {
 	lw.mu.Lock()
 	q := lw.waitingQueues[w.LockTS]
-	lw.mu.Unlock()
 	if q != nil {
 		q.removeWaiter(w)
 	}
+	lw.mu.Unlock()
 }
 
 // WakeUpDetection wakes up waiters waiting for deadlock detection results
 func (lw *Manager) WakeUpForDeadlock(resp *deadlock.DeadlockResponse) {
+	var (
+		waiter     *Waiter
+		waitForTxn uint64
+	)
+	waitForTxn = resp.Entry.WaitForTxn
 	lw.mu.Lock()
-	q := lw.waitingQueues[resp.Entry.WaitForTxn]
-	lw.mu.Unlock()
+	q := lw.waitingQueues[waitForTxn]
 	if q != nil {
-		q.mu.Lock()
-		for i, waiter := range q.waiters {
+		for i, curWaiter := range q.waiters {
 			// there should be no duplicated waiters
-			if waiter.startTS == resp.Entry.Txn && waiter.KeyHash == resp.Entry.KeyHash {
+			if curWaiter.startTS == resp.Entry.Txn && curWaiter.KeyHash == resp.Entry.KeyHash {
 				log.Infof("deadlock detection response got for entry=%v", resp.Entry)
-				// remove this waiter
+				waiter = curWaiter
 				q.waiters = append(q.waiters[:i], q.waiters[i+1:]...)
-				waiter.ch <- Result{DeadlockResp: resp}
 				break
 			}
 		}
-		q.mu.Unlock()
+		if len(q.waiters) == 0 {
+			delete(lw.waitingQueues, waitForTxn)
+		}
+	}
+	lw.mu.Unlock()
+	if waiter != nil {
+		waiter.ch <- WaitResult{DeadlockResp: resp}
+		log.Infof("wakeup txn=%v blocked by txn=%v because of deadlock, keyHash=%v, deadlockKeyHash=%v",
+			resp.Entry.Txn, waitForTxn, resp.Entry.KeyHash, resp.DeadlockKeyHash)
 	}
 }

--- a/util/lockwaiter/lockwaiter_test.go
+++ b/util/lockwaiter/lockwaiter_test.go
@@ -1,0 +1,127 @@
+package lockwaiter
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ngaut/log"
+	. "github.com/pingcap/check"
+	deadlockPb "github.com/pingcap/kvproto/pkg/deadlock"
+)
+
+func TestT(t *testing.T) {
+	TestingT(t)
+}
+
+var _ = Suite(&testLockwaiter{})
+
+type testLockwaiter struct{}
+
+func (t *testLockwaiter) TestLockwaiterBasic(c *C) {
+	mgr := NewManager()
+
+	mgr.NewWaiter(1, 2, 100, 10)
+
+	// basic check queue and waiter
+	q := mgr.waitingQueues[2]
+	c.Assert(q, NotNil)
+	waiter := q.waiters[0]
+	c.Assert(waiter.startTS, Equals, uint64(1))
+	c.Assert(waiter.LockTS, Equals, uint64(2))
+	c.Assert(waiter.KeyHash, Equals, uint64(100))
+
+	// check ready waiters
+	keyHash := make([]uint64, 0, 10)
+	keyHash = append(keyHash, 100)
+	rdyWaiters, remainSize := q.getReadyWaiters(keyHash)
+	rdyWaiter := rdyWaiters[0]
+	c.Assert(remainSize, Equals, 0)
+	c.Assert(rdyWaiter.startTS, Equals, uint64(1))
+	c.Assert(rdyWaiter.LockTS, Equals, uint64(2))
+	c.Assert(rdyWaiter.KeyHash, Equals, uint64(100))
+	q.waiters = rdyWaiters
+
+	// basic wake up test
+	mgr.WakeUp(2, 222, keyHash)
+	res := <-waiter.ch
+	c.Assert(res.CommitTS, Equals, uint64(222))
+	c.Assert(len(q.waiters), Equals, 0)
+	q = mgr.waitingQueues[2]
+	// verify queue deleted from map
+	c.Assert(q, IsNil)
+
+	// basic wake up for deadlock test
+	waiter = mgr.NewWaiter(3, 4, 300, 10)
+	resp := &deadlockPb.DeadlockResponse{}
+	resp.Entry.Txn = 3
+	resp.Entry.WaitForTxn = 4
+	resp.Entry.KeyHash = 300
+	resp.DeadlockKeyHash = 30192
+	mgr.WakeUpForDeadlock(resp)
+	res = <-waiter.ch
+	c.Assert(res.DeadlockResp, NotNil)
+	c.Assert(res.DeadlockResp.Entry.Txn, Equals, uint64(3))
+	c.Assert(res.DeadlockResp.Entry.WaitForTxn, Equals, uint64(4))
+	c.Assert(res.DeadlockResp.Entry.KeyHash, Equals, uint64(300))
+	c.Assert(res.DeadlockResp.DeadlockKeyHash, Equals, uint64(30192))
+	q = mgr.waitingQueues[4]
+	// verify queue deleted from map
+	c.Assert(q, IsNil)
+}
+
+func (t *testLockwaiter) TestLockwaiterConcurrent(c *C) {
+	mgr := NewManager()
+	wg := &sync.WaitGroup{}
+	endWg := &sync.WaitGroup{}
+	waitForTxn := uint64(100)
+	commitTs := uint64(199)
+	deadlockKeyHash := uint64(299)
+	numbers := uint64(10)
+	for i := uint64(0); i < numbers; i++ {
+		wg.Add(1)
+		endWg.Add(1)
+		go func(num uint64) {
+			defer endWg.Done()
+			waiter := mgr.NewWaiter(num, waitForTxn, num*10, 100*time.Millisecond)
+			// i == numbers - 1 use CleanUp Waiter and the results will be timeout
+			if num == numbers-1 {
+				mgr.CleanUp(waiter)
+				wg.Done()
+				res := waiter.Wait()
+				c.Assert(res.Position, Equals, WaitTimeout)
+				c.Assert(res.CommitTS, Equals, uint64(0))
+				c.Assert(res.DeadlockResp, IsNil)
+			} else {
+				wg.Done()
+				res := waiter.Wait()
+				// even woken up by commit
+				if num%2 == 0 {
+					c.Assert(res.CommitTS, Equals, commitTs)
+				} else {
+					// odd woken up by deadlock
+					c.Assert(res.DeadlockResp, NotNil)
+					c.Assert(res.DeadlockResp.DeadlockKeyHash, Equals, deadlockKeyHash)
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+	keyHashes := make([]uint64, 0, 4)
+	resp := &deadlockPb.DeadlockResponse{}
+	for i := uint64(0); i < numbers; i++ {
+		keyHashes = keyHashes[:0]
+		if i%2 == 0 {
+			log.Infof("wakeup i=%v", i)
+			mgr.WakeUp(waitForTxn, commitTs, append(keyHashes, i*10))
+		} else {
+			log.Infof("deadlock wakeup i=%v", i)
+			resp.DeadlockKeyHash = deadlockKeyHash
+			resp.Entry.Txn = i
+			resp.Entry.WaitForTxn = waitForTxn
+			resp.Entry.KeyHash = i * 10
+			mgr.WakeUpForDeadlock(resp)
+		}
+	}
+	endWg.Wait()
+}


### PR DESCRIPTION
Issue #257 

two related changes could be reviewed separately #269 #270 

Support distributed deadlock detection

- 1. Implement `deadlock` proto related RPC server interface
- 2. Wrap former `detector`  into new `DeadLockDetector`, add role to this new detector, and process requests based on current role(leader/follower)
- 3. Add `detectConn` and `detectClient` to do stream `send` and `recv` [this wrapping removed]
- 4. Add code path to process first region role change callback named `OnRoleChange`
- 5. Add recycling utility for detector wait map
- 6. Move the detector source code and test case from the dependent tidb package to local `tikv.detector.go` , and add some extra utilities.
- 7. Refactor lock waiter manager, remove the queue mutex

The storage engine still has some problems #267 #268,  the distributed tests are not done yet.