### PR TITLE
tiny refactor on raftstore

### DIFF
--- a/tikv/cop_handler_test.go
+++ b/tikv/cop_handler_test.go
@@ -73,7 +73,7 @@ func newTestStore() (*testStore, error) {
 		RollbackStore: lockstore.NewMemStore(4096),
 	}
 	writer := NewDBWriter(dbBundle, safePoint)
-	store := NewMVCCStore(dbBundle, dbPath, safePoint, writer)
+	store := NewMVCCStore(dbBundle, dbPath, safePoint, writer, nil)
 	svr := &Server{mvccStore: store}
 	return &testStore{
 		mvccStore: store,

--- a/tikv/raftstore/fsm_store.go
+++ b/tikv/raftstore/fsm_store.go
@@ -66,8 +66,7 @@ type PollContext struct {
 	cfg                  *Config
 	engine               *Engines
 	applyMsgs            *applyMsgs
-	needFlushTrans       bool
-	ReadyRes             []ReadyICPair
+	ReadyRes             []*ReadyICPair
 	kvWB                 *WriteBatch
 	raftWB               *WriteBatch
 	syncLog              bool

--- a/tikv/raftstore/peer_storage_test.go
+++ b/tikv/raftstore/peer_storage_test.go
@@ -40,10 +40,10 @@ func TestPeerStorageTerm(t *testing.T) {
 
 func appendEnts(t *testing.T, peerStore *PeerStorage, ents []eraftpb.Entry) {
 	ctx := NewInvokeContext(peerStore)
-	readyCtx := new(readyContext)
-	require.Nil(t, peerStore.Append(ctx, ents, readyCtx))
-	ctx.saveRaftStateTo(readyCtx.RaftWB())
-	require.Nil(t, peerStore.Engines.WriteRaft(readyCtx.RaftWB()))
+	raftWB := new(WriteBatch)
+	require.Nil(t, peerStore.Append(ctx, ents, raftWB))
+	ctx.saveRaftStateTo(raftWB)
+	require.Nil(t, peerStore.Engines.WriteRaft(raftWB))
 	peerStore.raftState = ctx.RaftState
 }
 


### PR DESCRIPTION
- Only pass necessary parameter instead of the whole PollContext to Peer, so we can infer what a method gonna do.

- remove the unused SyncLog state