### PR TITLE
snapshot apply: fix region pending apply processing

### DIFF
--- a/tikv/raftstore/worker.go
+++ b/tikv/raftstore/worker.go
@@ -828,7 +828,6 @@ func (r *regionRunner) handlePendingApplies() {
 		// Should not handle too many applies than the number of files that can be ingested.
 		// Check level 0 every time because we can not make sure how does the number of level 0 files change.
 		if r.ctx.ingestMaybeStall() {
-			log.Warnf("ingestMaybeStall break current pending applies")
 			break
 		}
 		// Try to apply task, if apply failed, throw away this task and let sender retry

--- a/tikv/raftstore/worker.go
+++ b/tikv/raftstore/worker.go
@@ -706,6 +706,7 @@ type regionRunner struct {
 	// we may delay some apply tasks if level 0 files to write stall threshold,
 	// pending_applies records all delayed apply task, and will check again later
 	pendingApplies []task
+	leftTasks      []task
 
 	builderFile    *os.File
 	builder        *table.Builder
@@ -824,15 +825,19 @@ func (r *regionRunner) finishApply() error {
 
 // handlePendingApplies tries to apply pending tasks if there is some.
 func (r *regionRunner) handlePendingApplies() {
-	for _, apply := range r.pendingApplies {
+	r.leftTasks = r.leftTasks[:0]
+	for idx, apply := range r.pendingApplies {
 		// Should not handle too many applies than the number of files that can be ingested.
 		// Check level 0 every time because we can not make sure how does the number of level 0 files change.
 		if r.ctx.ingestMaybeStall() {
+			log.Warnf("ingestMaybeStall break current pending applies")
+			r.leftTasks = append(r.leftTasks, r.pendingApplies[idx:]...)
 			break
 		}
 
 		if err := r.resetBuilder(); err != nil {
 			log.Error(err)
+			r.leftTasks = append(r.leftTasks, apply)
 			continue
 		}
 
@@ -840,15 +845,18 @@ func (r *regionRunner) handlePendingApplies() {
 		result, err := r.ctx.handleApply(task.regionId, task.status, r.builder, r.oldBuilder)
 		if err != nil {
 			log.Error(err)
+			r.leftTasks = append(r.leftTasks, apply)
 			continue
 		}
 		if err := r.handleApplyResult(result); err != nil {
 			log.Error(err)
+			r.leftTasks = append(r.leftTasks, apply)
 		}
 	}
 	if err := r.finishApply(); err != nil {
 		log.Error(err)
 	}
+	r.pendingApplies = r.leftTasks
 }
 
 func (r *regionRunner) run(t task) {

--- a/tikv/raftstore/worker.go
+++ b/tikv/raftstore/worker.go
@@ -845,7 +845,7 @@ func (r *regionRunner) handlePendingApplies() {
 			log.Error(err)
 			continue
 		}
-		if err = r.handleApplyResult(result); err != nil {
+		if err := r.handleApplyResult(result); err != nil {
 			log.Error(err)
 		}
 	}

--- a/tikv/raftstore/worker.go
+++ b/tikv/raftstore/worker.go
@@ -831,7 +831,9 @@ func (r *regionRunner) handlePendingApplies() {
 			log.Warnf("ingestMaybeStall break current pending applies")
 			break
 		}
+		// Try to apply task, if apply failed, throw away this task and let sender retry
 		apply := r.pendingApplies[0]
+		r.pendingApplies = r.pendingApplies[1:]
 		if err := r.resetBuilder(); err != nil {
 			log.Error(err)
 			continue
@@ -845,10 +847,7 @@ func (r *regionRunner) handlePendingApplies() {
 		}
 		if err = r.handleApplyResult(result); err != nil {
 			log.Error(err)
-			continue
 		}
-		// Apply succeeded, remove this task from pending array
-		r.pendingApplies = r.pendingApplies[1:]
 	}
 	if err := r.finishApply(); err != nil {
 		log.Error(err)


### PR DESCRIPTION

- The `handlePendingApplies` processes apply tasks, which comes in request order in `pendingApplies` array, the successful task should be removed from the pending tasks array, otherwise, redundant processing  leads to `badger` ingestion error like `keys of external tables has overlap` 
- `TestPendingApplies` test case is fixed to make it compatible with the current interfaces

TODO, maybe we need to refactor more on the `handlePendingApplies` error processing path, and some more test cases needed to be added to verify error processing is ok(like reentrancy), to avoid breaking the data consistency

