### PR TITLE
fix dead lock detection for stand alone mode

### DIFF
--- a/tikv/region.go
+++ b/tikv/region.go
@@ -473,6 +473,12 @@ func NewStandAloneRegionManager(db *badger.DB, opts RegionOptions, pdc pd.Client
 				return errors.Trace(err)
 			}
 			rm.regions[r.meta.Id] = r
+			req := &pdpb.RegionHeartbeatRequest{
+				Region:          r.meta,
+				Leader:          r.meta.Peers[0],
+				ApproximateSize: uint64(r.approximateSize),
+			}
+			rm.pdc.ReportRegion(req)
 		}
 		return nil
 	})

--- a/unistore-server/main.go
+++ b/unistore-server/main.go
@@ -204,6 +204,7 @@ func setupStandAlongInnerServer(bundle *mvcc.DBBundle, safePoint *tikv.SafePoint
 	innerServer := tikv.NewStandAlongInnerServer(bundle)
 	innerServer.Setup(pdClient)
 	store := tikv.NewMVCCStore(bundle, conf.Engine.DBPath, safePoint, tikv.NewDBWriter(bundle, safePoint), pdClient)
+	store.DeadlockDetectSvr.ChangeRole(tikv.Leader)
 	rm := tikv.NewStandAloneRegionManager(bundle.DB, regionOpts, pdClient)
 
 	if err := innerServer.Start(pdClient); err != nil {


### PR DESCRIPTION
* Close grpc connection when rebuild stream, otherwise the leaked socket will finally result in `too many open files` error.
* Set role when server starts in stand-alone mode.
* Report leader peer to PD when server start.
PTAL @coocood @cfzjywxk