### PR TITLE
refactor raftstore

### DIFF
--- a/tikv/raftstore/fsm_peer.go
+++ b/tikv/raftstore/fsm_peer.go
@@ -93,8 +93,16 @@ func (pf *peerFsm) regionID() uint64 {
 	return pf.peer.regionId
 }
 
+func (d *peerFsm) region() *metapb.Region {
+	return d.peer.Store().region
+}
+
 func (pf *peerFsm) getPeer() *Peer {
 	return pf.peer
+}
+
+func (d *peerFsm) storeID() uint64 {
+	return d.peer.Meta.StoreId
 }
 
 func (pf *peerFsm) peerID() uint64 {
@@ -117,23 +125,23 @@ func (pf *peerFsm) hasPendingMergeApplyResult() bool {
 	return pf.peer.PendingMergeApplyResult != nil
 }
 
-type peerFsmDelegate struct {
-	*peerFsm
-	ctx *PollContext
+func (pf *peerFsm) tag() string {
+	return pf.peer.Tag
 }
 
-func newPeerFsmDelegate(fsm *peerFsm, ctx *PollContext) *peerFsmDelegate {
-	return &peerFsmDelegate{
+type peerMsgHandler struct {
+	*peerFsm
+	ctx *RaftContext
+}
+
+func newRaftMsgHandler(fsm *peerFsm, ctx *RaftContext) *peerMsgHandler {
+	return &peerMsgHandler{
 		peerFsm: fsm,
 		ctx:     ctx,
 	}
 }
 
-func (d *peerFsmDelegate) tag() string {
-	return d.peer.Tag
-}
-
-func (d *peerFsmDelegate) handleMsgs(msgs []Msg) {
+func (d *peerMsgHandler) HandleMsgs(msgs ...Msg) {
 	for _, msg := range msgs {
 		switch msg.Type {
 		case MsgTypeRaftMessage:
@@ -180,13 +188,13 @@ func (d *peerFsmDelegate) handleMsgs(msgs []Msg) {
 		case MsgTypeClearRegionSize:
 			d.onClearRegionSize()
 		case MsgTypeStart:
-			d.start()
+			d.startTicker()
 		case MsgTypeNoop:
 		}
 	}
 }
 
-func (d *peerFsmDelegate) onTick() {
+func (d *peerMsgHandler) onTick() {
 	if d.stopped {
 		return
 	}
@@ -212,7 +220,7 @@ func (d *peerFsmDelegate) onTick() {
 	d.ctx.tickDriverCh <- d.regionID()
 }
 
-func (d *peerFsmDelegate) start() {
+func (d *peerMsgHandler) startTicker() {
 	if d.peer.PendingMergeState != nil {
 		d.notifyPrepareMerge()
 	}
@@ -226,15 +234,15 @@ func (d *peerFsmDelegate) start() {
 	d.onCheckMerge()
 }
 
-func (d *peerFsmDelegate) notifyPrepareMerge() {
+func (d *peerMsgHandler) notifyPrepareMerge() {
 	// TODO: merge func
 }
 
-func (d *peerFsmDelegate) resumeHandlePendingApplyResult() bool {
+func (d *peerMsgHandler) resumeHandlePendingApplyResult() bool {
 	return false // TODO: merge func
 }
 
-func (d *peerFsmDelegate) onGCSnap(snaps []SnapKeyWithSending) {
+func (d *peerMsgHandler) onGCSnap(snaps []SnapKeyWithSending) {
 	store := d.peer.Store()
 	compactedIdx := store.truncatedIndex()
 	compactedTerm := store.truncatedTerm()
@@ -270,12 +278,12 @@ func (d *peerFsmDelegate) onGCSnap(snaps []SnapKeyWithSending) {
 	}
 }
 
-func (d *peerFsmDelegate) onClearRegionSize() {
+func (d *peerMsgHandler) onClearRegionSize() {
 	d.peer.ApproximateSize = nil
 	d.peer.ApproximateKeys = nil
 }
 
-func (d *peerFsmDelegate) onSignificantMsg(msg *MsgSignificant) {
+func (d *peerMsgHandler) onSignificantMsg(msg *MsgSignificant) {
 	switch msg.Type {
 	case MsgSignificantTypeStatus:
 		// Report snapshot status to the corresponding peer.
@@ -285,7 +293,7 @@ func (d *peerFsmDelegate) onSignificantMsg(msg *MsgSignificant) {
 	}
 }
 
-func (d *peerFsmDelegate) reportSnapshotStatus(toPeerID uint64, status raft.SnapshotStatus) {
+func (d *peerMsgHandler) reportSnapshotStatus(toPeerID uint64, status raft.SnapshotStatus) {
 	toPeer := d.peer.getPeerFromCache(toPeerID)
 	if toPeer == nil {
 		// If to_peer is gone, ignore this snapshot status
@@ -296,7 +304,7 @@ func (d *peerFsmDelegate) reportSnapshotStatus(toPeerID uint64, status raft.Snap
 	d.peer.RaftGroup.ReportSnapshot(toPeerID, status)
 }
 
-func (d *peerFsmDelegate) collectReady(proposals []*regionProposal) []*regionProposal {
+func (d *peerMsgHandler) HandleRaftReadyAppend(proposals []*regionProposal) []*regionProposal {
 	hasReady := d.hasReady
 	d.hasReady = false
 	if !hasReady || d.stopped {
@@ -318,9 +326,9 @@ func (d *peerFsmDelegate) collectReady(proposals []*regionProposal) []*regionPro
 	return proposals
 }
 
-func (d *peerFsmDelegate) postRaftReadyAppend(ready *raft.Ready, invokeCtx *InvokeContext) {
+func (d *peerMsgHandler) PostRaftReadyPersistent(ready *raft.Ready, invokeCtx *InvokeContext) {
 	isMerging := d.peer.PendingMergeState != nil
-	res := d.peer.PostRaftReadyAppend(d.ctx.trans, d.ctx.applyMsgs, ready, invokeCtx)
+	res := d.peer.PostRaftReadyPersistent(d.ctx.trans, d.ctx.applyMsgs, ready, invokeCtx)
 	d.peer.HandleRaftReadyApply(d.ctx.engine.kv, d.ctx.applyMsgs, ready)
 	hasSnapshot := false
 	if res != nil {
@@ -333,19 +341,7 @@ func (d *peerFsmDelegate) postRaftReadyAppend(ready *raft.Ready, invokeCtx *Invo
 	}
 }
 
-func (d *peerFsmDelegate) regionID() uint64 {
-	return d.peer.regionId
-}
-
-func (d *peerFsmDelegate) region() *metapb.Region {
-	return d.peer.Store().region
-}
-
-func (d *peerFsmDelegate) storeID() uint64 {
-	return d.peer.Meta.StoreId
-}
-
-func (d *peerFsmDelegate) onRaftBaseTick() {
+func (d *peerMsgHandler) onRaftBaseTick() {
 	if d.peer.PendingRemove {
 		return
 	}
@@ -364,7 +360,7 @@ func (d *peerFsmDelegate) onRaftBaseTick() {
 	d.ticker.schedule(PeerTickRaft)
 }
 
-func (d *peerFsmDelegate) onApplyResult(res *applyTaskRes) {
+func (d *peerMsgHandler) onApplyResult(res *applyTaskRes) {
 	if res.destroyPeerID != 0 {
 		y.Assert(res.destroyPeerID == d.peerID())
 		d.destroyPeer(false)
@@ -389,7 +385,7 @@ func (d *peerFsmDelegate) onApplyResult(res *applyTaskRes) {
 	}
 }
 
-func (d *peerFsmDelegate) onRaftMsg(msg *rspb.RaftMessage) error {
+func (d *peerMsgHandler) onRaftMsg(msg *rspb.RaftMessage) error {
 	log.Debugf("%s handle raft message %s from %d to %d",
 		d.tag(), msg.GetMessage().GetMsgType(), msg.GetFromPeer().GetId(), msg.GetToPeer().GetId())
 	if !d.validateRaftMessage(msg) {
@@ -445,7 +441,7 @@ func (d *peerFsmDelegate) onRaftMsg(msg *rspb.RaftMessage) error {
 }
 
 // return false means the message is invalid, and can be ignored.
-func (d *peerFsmDelegate) validateRaftMessage(msg *rspb.RaftMessage) bool {
+func (d *peerMsgHandler) validateRaftMessage(msg *rspb.RaftMessage) bool {
 	regionID := msg.GetRegionId()
 	from := msg.GetFromPeer()
 	to := msg.GetToPeer()
@@ -465,7 +461,7 @@ func (d *peerFsmDelegate) validateRaftMessage(msg *rspb.RaftMessage) bool {
 /// Checks if the message is sent to the correct peer.
 ///
 /// Returns true means that the message can be dropped silently.
-func (d *peerFsmDelegate) checkMessage(msg *rspb.RaftMessage) bool {
+func (d *peerMsgHandler) checkMessage(msg *rspb.RaftMessage) bool {
 	fromEpoch := msg.GetRegionEpoch()
 	isVoteMsg := isVoteMessage(msg.Message)
 	fromStoreID := msg.FromPeer.GetStoreId()
@@ -491,7 +487,7 @@ func (d *peerFsmDelegate) checkMessage(msg *rspb.RaftMessage) bool {
 	region := d.peer.Region()
 	if IsEpochStale(fromEpoch, region.RegionEpoch) && findPeer(region, fromStoreID) == nil {
 		// The message is stale and not in current region.
-		d.ctx.handleStaleMsg(msg, region.RegionEpoch, isVoteMsg, nil)
+		handleStaleMsg(d.ctx.trans, msg, region.RegionEpoch, isVoteMsg, nil)
 		return true
 	}
 	target := msg.GetToPeer()
@@ -511,11 +507,39 @@ func (d *peerFsmDelegate) checkMessage(msg *rspb.RaftMessage) bool {
 	return false
 }
 
-func (d *peerFsmDelegate) needGCMerge(msg *rspb.RaftMessage) (bool, error) {
+func handleStaleMsg(trans Transport, msg *rspb.RaftMessage, curEpoch *metapb.RegionEpoch,
+	needGC bool, targetRegion *metapb.Region) {
+	regionID := msg.RegionId
+	fromPeer := msg.FromPeer
+	toPeer := msg.ToPeer
+	msgType := msg.Message.GetMsgType()
+
+	if !needGC {
+		log.Infof("[region %d] raft message %s is stale, current %v ignore it",
+			regionID, msgType, curEpoch)
+		return
+	}
+	gcMsg := &rspb.RaftMessage{
+		RegionId:    regionID,
+		FromPeer:    fromPeer,
+		ToPeer:      toPeer,
+		RegionEpoch: curEpoch,
+	}
+	if targetRegion != nil {
+		gcMsg.MergeTarget = targetRegion
+	} else {
+		gcMsg.IsTombstone = true
+	}
+	if err := trans.Send(gcMsg); err != nil {
+		log.Errorf("[region %d] send message failed %v", regionID, err)
+	}
+}
+
+func (d *peerMsgHandler) needGCMerge(msg *rspb.RaftMessage) (bool, error) {
 	return false, nil // TODO: merge func
 }
 
-func (d *peerFsmDelegate) handleGCPeerMsg(msg *rspb.RaftMessage) {
+func (d *peerMsgHandler) handleGCPeerMsg(msg *rspb.RaftMessage) {
 	fromEpoch := msg.RegionEpoch
 	if !IsEpochStale(d.peer.Region().RegionEpoch, fromEpoch) {
 		return
@@ -533,7 +557,7 @@ func (d *peerFsmDelegate) handleGCPeerMsg(msg *rspb.RaftMessage) {
 
 // Returns `None` if the `msg` doesn't contain a snapshot or it contains a snapshot which
 // doesn't conflict with any other snapshots or regions. Otherwise a `SnapKey` is returned.
-func (d *peerFsmDelegate) checkSnapshot(msg *rspb.RaftMessage) (*SnapKey, error) {
+func (d *peerMsgHandler) checkSnapshot(msg *rspb.RaftMessage) (*SnapKey, error) {
 	if msg.Message.Snapshot == nil {
 		return nil, nil
 	}
@@ -616,7 +640,7 @@ func (d *peerFsmDelegate) checkSnapshot(msg *rspb.RaftMessage) (*SnapKey, error)
 	return nil, nil
 }
 
-func (d *peerFsmDelegate) findOverlapRegions(storeMeta *storeMeta, snapRegion *metapb.Region) (result []*metapb.Region) {
+func (d *peerMsgHandler) findOverlapRegions(storeMeta *storeMeta, snapRegion *metapb.Region) (result []*metapb.Region) {
 	it := storeMeta.regionRanges.NewIterator()
 	it.Seek(snapRegion.StartKey)
 	for it.Valid() {
@@ -635,7 +659,7 @@ func (d *peerFsmDelegate) findOverlapRegions(storeMeta *storeMeta, snapRegion *m
 	return
 }
 
-func (d *peerFsmDelegate) handleDestroyPeer(job *DestroyPeerJob) bool {
+func (d *peerMsgHandler) handleDestroyPeer(job *DestroyPeerJob) bool {
 	if job.Initialized {
 		d.ctx.applyMsgs.appendMsg(job.RegionId, NewPeerMsg(MsgTypeApplyDestroy, job.RegionId, nil))
 	}
@@ -647,7 +671,7 @@ func (d *peerFsmDelegate) handleDestroyPeer(job *DestroyPeerJob) bool {
 	return true
 }
 
-func (d *peerFsmDelegate) destroyPeer(mergeByTarget bool) {
+func (d *peerMsgHandler) destroyPeer(mergeByTarget bool) {
 	log.Infof("%s starts destroy [merged_by_target: %v]", d.tag(), mergeByTarget)
 	regionID := d.regionID()
 	// We can't destroy a peer which is applying snapshot.
@@ -698,7 +722,7 @@ func (d *peerFsmDelegate) destroyPeer(mergeByTarget bool) {
 	d.ctx.peerEventObserver.OnPeerDestroy(d.peer.getEventContext())
 }
 
-func (d *peerFsmDelegate) onReadyChangePeer(cp changePeer) {
+func (d *peerMsgHandler) onReadyChangePeer(cp changePeer) {
 	changeType := cp.confChange.ChangeType
 	d.peer.RaftGroup.ApplyConfChange(*cp.confChange)
 	if cp.confChange.NodeId == 0 {
@@ -758,7 +782,7 @@ func (d *peerFsmDelegate) onReadyChangePeer(cp changePeer) {
 	}
 }
 
-func (d *peerFsmDelegate) onReadyCompactLog(firstIndex uint64, truncatedIndex uint64) {
+func (d *peerMsgHandler) onReadyCompactLog(firstIndex uint64, truncatedIndex uint64) {
 	totalCnt := d.peer.LastApplyingIdx - firstIndex
 	// the size of current CompactLog command can be ignored.
 	remainCnt := d.peer.LastApplyingIdx - truncatedIndex - 1
@@ -777,7 +801,7 @@ func (d *peerFsmDelegate) onReadyCompactLog(firstIndex uint64, truncatedIndex ui
 	}
 }
 
-func (d *peerFsmDelegate) onReadySplitRegion(derived *metapb.Region, regions []*metapb.Region) {
+func (d *peerMsgHandler) onReadySplitRegion(derived *metapb.Region, regions []*metapb.Region) {
 	d.ctx.storeMetaLock.Lock()
 	defer d.ctx.storeMetaLock.Unlock()
 	meta := d.ctx.storeMeta
@@ -879,43 +903,43 @@ func (d *peerFsmDelegate) onReadySplitRegion(derived *metapb.Region, regions []*
 	d.ctx.peerEventObserver.OnSplitRegion(derived, regions, newPeers)
 }
 
-func (d *peerFsmDelegate) validateMergePeer(targetRegion *metapb.Region) (bool, error) {
+func (d *peerMsgHandler) validateMergePeer(targetRegion *metapb.Region) (bool, error) {
 	return false, nil // TODO: merge func
 }
 
-func (d *peerFsmDelegate) scheduleMerge() error {
+func (d *peerMsgHandler) scheduleMerge() error {
 	return nil // TODO: merge func
 }
 
-func (d *peerFsmDelegate) rollbackMerge() {
+func (d *peerMsgHandler) rollbackMerge() {
 	// TODO: merge func
 }
 
-func (d *peerFsmDelegate) onCheckMerge() {
+func (d *peerMsgHandler) onCheckMerge() {
 	// TODO: merge func
 }
 
-func (d *peerFsmDelegate) onReadyPrepareMerge(region *metapb.Region, state *rspb.MergeState, merged bool) {
+func (d *peerMsgHandler) onReadyPrepareMerge(region *metapb.Region, state *rspb.MergeState, merged bool) {
 	// TODO: merge func
 }
 
-func (d *peerFsmDelegate) onReadyCommitMerge(region, source *metapb.Region) *uint32 {
+func (d *peerMsgHandler) onReadyCommitMerge(region, source *metapb.Region) *uint32 {
 	return nil // TODO: merge func
 }
 
-func (d *peerFsmDelegate) onReadyRollbackMerge(commit uint64, region *metapb.Region) {
+func (d *peerMsgHandler) onReadyRollbackMerge(commit uint64, region *metapb.Region) {
 	// TODO: merge func
 }
 
-func (d *peerFsmDelegate) onMergeResult(target *metapb.Peer, stale bool) {
+func (d *peerMsgHandler) onMergeResult(target *metapb.Peer, stale bool) {
 	// TODO: merge func
 }
 
-func (d *peerFsmDelegate) onStaleMerge() {
+func (d *peerMsgHandler) onStaleMerge() {
 	// TODO: merge func
 }
 
-func (d *peerFsmDelegate) onReadyApplySnapshot(applyResult *ApplySnapResult) {
+func (d *peerMsgHandler) onReadyApplySnapshot(applyResult *ApplySnapResult) {
 	prevRegion := applyResult.PrevRegion
 	region := applyResult.Region
 
@@ -936,7 +960,7 @@ func (d *peerFsmDelegate) onReadyApplySnapshot(applyResult *ApplySnapResult) {
 	d.ctx.peerEventObserver.OnPeerApplySnap(d.peer.getEventContext(), region)
 }
 
-func (d *peerFsmDelegate) onReadyResult(merged bool, execResults []execResult) (*uint32, []execResult) {
+func (d *peerMsgHandler) onReadyResult(merged bool, execResults []execResult) (*uint32, []execResult) {
 	if len(execResults) == 0 {
 		return nil, nil
 	}
@@ -971,11 +995,11 @@ func (d *peerFsmDelegate) onReadyResult(merged bool, execResults []execResult) (
 	return nil, nil
 }
 
-func (d *peerFsmDelegate) checkMergeProposal(msg *raft_cmdpb.RaftCmdRequest) error {
+func (d *peerMsgHandler) checkMergeProposal(msg *raft_cmdpb.RaftCmdRequest) error {
 	return nil // TODO: merge func
 }
 
-func (d *peerFsmDelegate) preProposeRaftCommand(req *raft_cmdpb.RaftCmdRequest) (*raft_cmdpb.RaftCmdResponse, error) {
+func (d *peerMsgHandler) preProposeRaftCommand(req *raft_cmdpb.RaftCmdRequest) (*raft_cmdpb.RaftCmdResponse, error) {
 	// Check store_id, make sure that the msg is dispatched to the right place.
 	if err := checkStoreID(req, d.storeID()); err != nil {
 		return nil, err
@@ -1015,7 +1039,7 @@ func (d *peerFsmDelegate) preProposeRaftCommand(req *raft_cmdpb.RaftCmdRequest) 
 	return nil, err
 }
 
-func (d *peerFsmDelegate) proposeRaftCommand(msg *raft_cmdpb.RaftCmdRequest, cb *Callback) {
+func (d *peerMsgHandler) proposeRaftCommand(msg *raft_cmdpb.RaftCmdRequest, cb *Callback) {
 	resp, err := d.preProposeRaftCommand(msg)
 	if err != nil {
 		cb.Done(ErrResp(err))
@@ -1052,7 +1076,7 @@ func (d *peerFsmDelegate) proposeRaftCommand(msg *raft_cmdpb.RaftCmdRequest, cb 
 	// we will call the callback with timeout error.
 }
 
-func (d *peerFsmDelegate) findSiblingRegion() *metapb.Region {
+func (d *peerMsgHandler) findSiblingRegion() *metapb.Region {
 	var start []byte
 	var skipFirst bool
 	if d.ctx.cfg.RightDeriveWhenSplit {
@@ -1078,7 +1102,7 @@ func (d *peerFsmDelegate) findSiblingRegion() *metapb.Region {
 	return meta.regions[regionID]
 }
 
-func (d *peerFsmDelegate) onRaftGCLogTick() {
+func (d *peerMsgHandler) onRaftGCLogTick() {
 	d.ticker.schedule(PeerTickRaftLogGC)
 
 	// As leader, we would not keep caches for the peers that didn't response heartbeat in the
@@ -1165,7 +1189,7 @@ func (d *peerFsmDelegate) onRaftGCLogTick() {
 	d.proposeRaftCommand(request, nil)
 }
 
-func (d *peerFsmDelegate) onSplitRegionCheckTick() {
+func (d *peerMsgHandler) onSplitRegionCheckTick() {
 	d.ticker.schedule(PeerTickSplitRegionCheck)
 	// To avoid frequent scan, we only add new scan tasks if all previous tasks
 	// have finished.
@@ -1201,7 +1225,7 @@ func isSameTable(leftKey, rightKey []byte) bool {
 		bytes.Compare(leftKey[:tablecodec.TableSplitKeyLen], rightKey[:tablecodec.TableSplitKeyLen]) == 0
 }
 
-func (d *peerFsmDelegate) onPrepareSplitRegion(regionEpoch *metapb.RegionEpoch, splitKeys [][]byte, cb *Callback) {
+func (d *peerMsgHandler) onPrepareSplitRegion(regionEpoch *metapb.RegionEpoch, splitKeys [][]byte, cb *Callback) {
 	if err := d.validateSplitRegion(regionEpoch, splitKeys); err != nil {
 		cb.Done(ErrResp(err))
 		return
@@ -1219,7 +1243,7 @@ func (d *peerFsmDelegate) onPrepareSplitRegion(regionEpoch *metapb.RegionEpoch, 
 	}
 }
 
-func (d *peerFsmDelegate) validateSplitRegion(epoch *metapb.RegionEpoch, splitKeys [][]byte) error {
+func (d *peerMsgHandler) validateSplitRegion(epoch *metapb.RegionEpoch, splitKeys [][]byte) error {
 	if len(splitKeys) == 0 {
 		err := errors.Errorf("%s no split key is specified", d.tag())
 		log.Error(err)
@@ -1258,19 +1282,19 @@ func (d *peerFsmDelegate) validateSplitRegion(epoch *metapb.RegionEpoch, splitKe
 	return nil
 }
 
-func (d *peerFsmDelegate) onApproximateRegionSize(size uint64) {
+func (d *peerMsgHandler) onApproximateRegionSize(size uint64) {
 	d.peer.ApproximateSize = &size
 }
 
-func (d *peerFsmDelegate) onApproximateRegionKeys(keys uint64) {
+func (d *peerMsgHandler) onApproximateRegionKeys(keys uint64) {
 	d.peer.ApproximateKeys = &keys
 }
 
-func (d *peerFsmDelegate) onCompactionDeclinedBytes(declinedBytes uint64) {
+func (d *peerMsgHandler) onCompactionDeclinedBytes(declinedBytes uint64) {
 	d.peer.CompactionDeclinedBytes += declinedBytes
 }
 
-func (d *peerFsmDelegate) onScheduleHalfSplitRegion(regionEpoch *metapb.RegionEpoch) {
+func (d *peerMsgHandler) onScheduleHalfSplitRegion(regionEpoch *metapb.RegionEpoch) {
 	if !d.peer.IsLeader() {
 		log.Warnf("%s not leader, skip", d.tag())
 		return
@@ -1288,7 +1312,7 @@ func (d *peerFsmDelegate) onScheduleHalfSplitRegion(regionEpoch *metapb.RegionEp
 	}
 }
 
-func (d *peerFsmDelegate) onPDHeartbeatTick() {
+func (d *peerMsgHandler) onPDHeartbeatTick() {
 	d.ticker.schedule(PeerTickPdHeartbeat)
 	d.peer.CheckPeers()
 
@@ -1298,7 +1322,7 @@ func (d *peerFsmDelegate) onPDHeartbeatTick() {
 	d.peer.HeartbeatPd(d.ctx.pdScheduler)
 }
 
-func (d *peerFsmDelegate) onCheckPeerStaleStateTick() {
+func (d *peerMsgHandler) onCheckPeerStaleStateTick() {
 	if d.peer.PendingRemove {
 		return
 	}
@@ -1343,7 +1367,7 @@ func (d *peerFsmDelegate) onCheckPeerStaleStateTick() {
 	}
 }
 
-func (d *peerFsmDelegate) onReadyComputeHash(region *metapb.Region, index uint64, snap *mvcc.DBSnapshot) {
+func (d *peerMsgHandler) onReadyComputeHash(region *metapb.Region, index uint64, snap *mvcc.DBSnapshot) {
 	d.peer.ConsistencyState.LastCheckTime = time.Now()
 	log.Infof("%s schedule compute hash task", d.tag())
 	d.ctx.computeHashScheduler <- task{
@@ -1356,11 +1380,11 @@ func (d *peerFsmDelegate) onReadyComputeHash(region *metapb.Region, index uint64
 	}
 }
 
-func (d *peerFsmDelegate) onReadyVerifyHash(expectedIndex uint64, expectedHash []byte) {
+func (d *peerMsgHandler) onReadyVerifyHash(expectedIndex uint64, expectedHash []byte) {
 	d.verifyAndStoreHash(expectedIndex, expectedHash)
 }
 
-func (d *peerFsmDelegate) onHashComputed(index uint64, hash []byte) {
+func (d *peerMsgHandler) onHashComputed(index uint64, hash []byte) {
 	if !d.verifyAndStoreHash(index, hash) {
 		return
 	}
@@ -1369,7 +1393,7 @@ func (d *peerFsmDelegate) onHashComputed(index uint64, hash []byte) {
 }
 
 /// Verify and store the hash to state. return true means the hash has been stored successfully.
-func (d *peerFsmDelegate) verifyAndStoreHash(expectedIndex uint64, expectedHash []byte) bool {
+func (d *peerMsgHandler) verifyAndStoreHash(expectedIndex uint64, expectedHash []byte) bool {
 	state := d.peer.ConsistencyState
 	index := state.Index
 	if expectedIndex < index {
@@ -1456,7 +1480,7 @@ func newCompactLogRequest(regionID uint64, peer *metapb.Peer, compactIndex, comp
 // to another file later.
 // Unlike other commands (write or admin), status commands only show current
 // store status, so no need to handle it in raft group.
-func (d *peerFsmDelegate) executeStatusCommand(request *raft_cmdpb.RaftCmdRequest) (*raft_cmdpb.RaftCmdResponse, error) {
+func (d *peerMsgHandler) executeStatusCommand(request *raft_cmdpb.RaftCmdRequest) (*raft_cmdpb.RaftCmdResponse, error) {
 	cmdType := request.StatusRequest.CmdType
 	var response *raft_cmdpb.StatusResponse
 	switch cmdType {
@@ -1480,7 +1504,7 @@ func (d *peerFsmDelegate) executeStatusCommand(request *raft_cmdpb.RaftCmdReques
 	return resp, nil // TODO: stub
 }
 
-func (d *peerFsmDelegate) executeRegionLeader() *raft_cmdpb.StatusResponse {
+func (d *peerMsgHandler) executeRegionLeader() *raft_cmdpb.StatusResponse {
 	resp := &raft_cmdpb.StatusResponse{}
 	if leader := d.peer.getPeerFromCache(d.peer.LeaderId()); leader != nil {
 		resp.RegionLeader = &raft_cmdpb.RegionLeaderResponse{
@@ -1490,7 +1514,7 @@ func (d *peerFsmDelegate) executeRegionLeader() *raft_cmdpb.StatusResponse {
 	return resp
 }
 
-func (d *peerFsmDelegate) executeRegionDetail(request *raft_cmdpb.RaftCmdRequest) (*raft_cmdpb.StatusResponse, error) {
+func (d *peerMsgHandler) executeRegionDetail(request *raft_cmdpb.RaftCmdRequest) (*raft_cmdpb.StatusResponse, error) {
 	if !d.peer.isInitialized() {
 		regionID := request.Header.RegionId
 		return nil, errors.Errorf("region %d not initialized", regionID)

--- a/tikv/raftstore/fsm_store.go
+++ b/tikv/raftstore/fsm_store.go
@@ -62,37 +62,44 @@ func (m *storeMeta) setRegion(region *metapb.Region, peer *Peer) {
 type mergeLock struct {
 }
 
-type PollContext struct {
+type GlobalContext struct {
 	cfg                  *Config
 	engine               *Engines
-	applyMsgs            *applyMsgs
-	ReadyRes             []*ReadyICPair
-	kvWB                 *WriteBatch
-	raftWB               *WriteBatch
-	syncLog              bool
+	store                *metapb.Store
 	storeMeta            *storeMeta
 	storeMetaLock        *sync.RWMutex
 	snapMgr              *SnapManager
-	pendingCount         int
-	hasReady             bool
 	router               *router
-	tickDriverCh         chan<- uint64
 	trans                Transport
-	queuedSnaps          map[uint64]struct{}
 	pdScheduler          chan<- task
-	raftLogGCScheduler   chan<- task
-	store                *metapb.Store
 	regionScheduler      chan<- task
-	splitCheckScheduler  chan<- task
 	computeHashScheduler chan<- task
+	raftLogGCScheduler   chan<- task
+	splitCheckScheduler  chan<- task
 	cleanUpSSTScheduler  chan<- task
 	compactScheduler     chan<- task
-	applyingSnapCount    *uint64
-	isBusy               bool
 	pdClient             pd.Client
-	globalStats          *storeStats
-	localStats           *storeStats
 	peerEventObserver    PeerEventObserver
+	globalStats          *storeStats
+	tickDriverCh         chan uint64
+}
+
+type StoreContext struct {
+	*GlobalContext
+	applyingSnapCount *uint64
+}
+
+type RaftContext struct {
+	*GlobalContext
+	applyMsgs    *applyMsgs
+	ReadyRes     []*ReadyICPair
+	kvWB         *WriteBatch
+	raftWB       *WriteBatch
+	pendingCount int
+	hasReady     bool
+	queuedSnaps  map[uint64]struct{}
+	isBusy       bool
+	localStats   *storeStats
 }
 
 type storeStats struct {
@@ -105,7 +112,7 @@ type Transport interface {
 	Send(msg *rspb.RaftMessage) error
 }
 
-func (pc *PollContext) flushLocalStats() {
+func (pc *RaftContext) flushLocalStats() {
 	if pc.localStats.engineTotalBytesWritten > 0 {
 		atomic.AddUint64(&pc.globalStats.engineTotalBytesWritten, pc.localStats.engineTotalBytesWritten)
 		pc.localStats.engineTotalBytesWritten = 0
@@ -117,50 +124,6 @@ func (pc *PollContext) flushLocalStats() {
 	if pc.localStats.isBusy > 0 {
 		atomic.StoreUint64(&pc.globalStats.isBusy, pc.localStats.isBusy)
 		pc.localStats.isBusy = 0
-	}
-}
-
-func (pc *PollContext) KVWB() *WriteBatch {
-	return pc.kvWB
-}
-
-func (pc *PollContext) RaftWB() *WriteBatch {
-	return pc.raftWB
-}
-
-func (pc *PollContext) SyncLog() bool {
-	return pc.syncLog
-}
-
-func (pc *PollContext) SetSyncLog(sync bool) {
-	pc.syncLog = sync
-}
-
-func (pc *PollContext) handleStaleMsg(msg *rspb.RaftMessage, curEpoch *metapb.RegionEpoch,
-	needGC bool, targetRegion *metapb.Region) {
-	regionID := msg.RegionId
-	fromPeer := msg.FromPeer
-	toPeer := msg.ToPeer
-	msgType := msg.Message.GetMsgType()
-
-	if !needGC {
-		log.Infof("[region %d] raft message %s is stale, current %v ignore it",
-			regionID, msgType, curEpoch)
-		return
-	}
-	gcMsg := &rspb.RaftMessage{
-		RegionId:    regionID,
-		FromPeer:    fromPeer,
-		ToPeer:      toPeer,
-		RegionEpoch: curEpoch,
-	}
-	if targetRegion != nil {
-		gcMsg.MergeTarget = targetRegion
-	} else {
-		gcMsg.IsTombstone = true
-	}
-	if err := pc.trans.Send(gcMsg); err != nil {
-		log.Errorf("[region %d] send message failed %v", regionID, err)
 	}
 }
 
@@ -184,16 +147,16 @@ func newStoreFsm(cfg *Config) (chan<- Msg, *storeFsm) {
 	return (chan<- Msg)(ch), fsm
 }
 
-type storeFsmDelegate struct {
+type storeMsgHandler struct {
 	*storeFsm
-	ctx *PollContext
+	ctx *StoreContext
 }
 
-func newStoreFsmDelegate(store *storeFsm, ctx *PollContext) *storeFsmDelegate {
-	return &storeFsmDelegate{storeFsm: store, ctx: ctx}
+func newStoreFsmDelegate(store *storeFsm, ctx *StoreContext) *storeMsgHandler {
+	return &storeMsgHandler{storeFsm: store, ctx: ctx}
 }
 
-func (d *storeFsmDelegate) onTick(tick StoreTick) {
+func (d *storeMsgHandler) onTick(tick StoreTick) {
 	switch tick {
 	case StoreTickCompactCheck:
 		d.onCompactCheckTick()
@@ -206,29 +169,27 @@ func (d *storeFsmDelegate) onTick(tick StoreTick) {
 	}
 }
 
-func (d *storeFsmDelegate) handleMessages(msgs []Msg) {
-	for _, msg := range msgs {
-		switch msg.Type {
-		case MsgTypeStoreRaftMessage:
-			if err := d.onRaftMessage(msg.Data.(*rspb.RaftMessage)); err != nil {
-				log.Errorf("handle raft message failed storeID %d, %v", d.id, err)
-			}
-		case MsgTypeStoreSnapshotStats:
-			d.storeHeartbeatPD()
-		case MsgTypeStoreClearRegionSizeInRange:
-			data := msg.Data.(*MsgStoreClearRegionSizeInRange)
-			d.clearRegionSizeInRange(data.StartKey, data.EndKey)
-		case MsgTypeStoreCompactedEvent:
-			d.onCompactionFinished(msg.Data.(*rocksdb.CompactedEvent))
-		case MsgTypeStoreTick:
-			d.onTick(msg.Data.(StoreTick))
-		case MsgTypeStoreStart:
-			d.start(msg.Data.(*metapb.Store))
+func (d *storeMsgHandler) handleMsg(msg Msg) {
+	switch msg.Type {
+	case MsgTypeStoreRaftMessage:
+		if err := d.onRaftMessage(msg.Data.(*rspb.RaftMessage)); err != nil {
+			log.Errorf("handle raft message failed storeID %d, %v", d.id, err)
 		}
+	case MsgTypeStoreSnapshotStats:
+		d.storeHeartbeatPD()
+	case MsgTypeStoreClearRegionSizeInRange:
+		data := msg.Data.(*MsgStoreClearRegionSizeInRange)
+		d.clearRegionSizeInRange(data.StartKey, data.EndKey)
+	case MsgTypeStoreCompactedEvent:
+		d.onCompactionFinished(msg.Data.(*rocksdb.CompactedEvent))
+	case MsgTypeStoreTick:
+		d.onTick(msg.Data.(StoreTick))
+	case MsgTypeStoreStart:
+		d.start(msg.Data.(*metapb.Store))
 	}
 }
 
-func (d *storeFsmDelegate) start(store *metapb.Store) {
+func (d *storeMsgHandler) start(store *metapb.Store) {
 	if d.startTime != nil {
 		panic(fmt.Sprintf("store %d unable to start again %s", d.id, store))
 	}
@@ -241,39 +202,16 @@ func (d *storeFsmDelegate) start(store *metapb.Store) {
 	d.ticker.scheduleStore(StoreTickConsistencyCheck)
 }
 
-type raftPollerBuilder struct {
-	cfg                  *Config
-	store                *metapb.Store
-	pdScheduler          chan<- task
-	resolverScheduler    chan<- task
-	snapScheduler        chan<- task
-	raftLogGCScheduler   chan<- task
-	computeHashScheduler chan<- task
-	splitCheckScheduler  chan<- task
-	regionScheduler      chan<- task
-	applyMsgs            *applyMsgs
-	router               *router
-	compactScheduler     chan<- task
-	storeMetaLock        *sync.RWMutex
-	storeMeta            *storeMeta
-	snapMgr              *SnapManager
-	trans                Transport
-	pdClient             pd.Client
-	engines              *Engines
-	applyingSnapCount    *uint64
-	tickDriverCh         chan uint64
-	peerEventObserver    PeerEventObserver
-}
-
-/// init Initialize this store. It scans the db engine, loads all regions
+/// loadPeers loads peers in this store. It scans the db engine, loads all regions
 /// and their peers from it, and schedules snapshot worker if necessary.
 /// WARN: This store should not be used before initialized.
-func (b *raftPollerBuilder) init() ([]*peerFsm, error) {
+func (bs *raftBatchSystem) loadPeers() ([]*peerFsm, error) {
 	// Scan region meta to get saved regions.
 	startKey := RegionMetaMinKey
 	endKey := RegionMetaMaxKey
-	kvEngine := b.engines.kv.DB
-	storeID := b.store.Id
+	ctx := bs.ctx
+	kvEngine := ctx.engine.kv.DB
+	storeID := ctx.store.Id
 
 	var totalCount, tombStoneCount, applyingCount int
 	var regionPeers []*peerFsm
@@ -283,9 +221,9 @@ func (b *raftPollerBuilder) init() ([]*peerFsm, error) {
 	raftWB := new(WriteBatch)
 	var applyingRegions []*metapb.Region
 	var mergingCount int
-	b.storeMetaLock.Lock()
-	defer b.storeMetaLock.Unlock()
-	meta := b.storeMeta
+	ctx.storeMetaLock.Lock()
+	defer ctx.storeMetaLock.Unlock()
+	meta := ctx.storeMeta
 	err := kvEngine.View(func(txn *badger.Txn) error {
 		it := dbreader.NewIterator(txn, false, startKey, endKey)
 		defer it.Close()
@@ -314,7 +252,7 @@ func (b *raftPollerBuilder) init() ([]*peerFsm, error) {
 			region := localState.Region
 			if localState.State == rspb.PeerState_Tombstone {
 				tombStoneCount++
-				b.clearStaleMeta(kvWB, raftWB, localState)
+				bs.clearStaleMeta(kvWB, raftWB, localState)
 				continue
 			}
 			if localState.State == rspb.PeerState_Applying {
@@ -325,11 +263,11 @@ func (b *raftPollerBuilder) init() ([]*peerFsm, error) {
 				continue
 			}
 
-			peer, err := createPeerFsm(storeID, b.cfg, b.regionScheduler, b.engines, region)
+			peer, err := createPeerFsm(storeID, ctx.cfg, ctx.regionScheduler, ctx.engine, region)
 			if err != nil {
 				return err
 			}
-			b.peerEventObserver.OnPeerCreate(peer.peer.getEventContext(), region)
+			ctx.peerEventObserver.OnPeerCreate(peer.peer.getEventContext(), region)
 			if localState.State == rspb.PeerState_Merging {
 				log.Infof("region %d is merging", regionID)
 				mergingCount++
@@ -347,16 +285,16 @@ func (b *raftPollerBuilder) init() ([]*peerFsm, error) {
 		return nil, err
 	}
 	if kvWB.size > 0 {
-		kvWB.MustWriteToKV(b.engines.kv)
+		kvWB.MustWriteToKV(ctx.engine.kv)
 	}
 	if raftWB.size > 0 {
-		raftWB.MustWriteToRaft(b.engines.raft)
+		raftWB.MustWriteToRaft(ctx.engine.raft)
 	}
 
 	// schedule applying snapshot after raft write batch were written.
 	for _, region := range applyingRegions {
 		log.Infof("region %d is applying snapshot", region.Id)
-		peer, err := createPeerFsm(storeID, b.cfg, b.regionScheduler, b.engines, region)
+		peer, err := createPeerFsm(storeID, ctx.cfg, ctx.regionScheduler, ctx.engine, region)
 		if err != nil {
 			return nil, err
 		}
@@ -370,52 +308,23 @@ func (b *raftPollerBuilder) init() ([]*peerFsm, error) {
 	return regionPeers, nil
 }
 
-func (b *raftPollerBuilder) clearStaleMeta(kvWB, raftWB *WriteBatch, originState *rspb.RegionLocalState) {
+func (bs *raftBatchSystem) clearStaleMeta(kvWB, raftWB *WriteBatch, originState *rspb.RegionLocalState) {
 	region := originState.Region
 	raftKey := RaftStateKey(region.Id)
 	raftState := raftState{}
-	val, err := getValue(b.engines.raft, raftKey)
+	val, err := getValue(bs.ctx.engine.raft, raftKey)
 	if err != nil {
 		// it has been cleaned up.
 		return
 	}
 	raftState.Unmarshal(val)
-	err = ClearMeta(b.engines, kvWB, raftWB, region.Id, raftState.lastIndex)
+	err = ClearMeta(bs.ctx.engine, kvWB, raftWB, region.Id, raftState.lastIndex)
 	if err != nil {
 		panic(err)
 	}
 	key := RegionStateKey(region.Id)
 	if err := kvWB.SetMsg(key, originState); err != nil {
 		panic(err)
-	}
-}
-
-func (b *raftPollerBuilder) build() *PollContext {
-	return &PollContext{
-		cfg:                  b.cfg,
-		store:                b.store,
-		pdScheduler:          b.pdScheduler,
-		raftLogGCScheduler:   b.raftLogGCScheduler,
-		computeHashScheduler: b.computeHashScheduler,
-		splitCheckScheduler:  b.splitCheckScheduler,
-		regionScheduler:      b.regionScheduler,
-		applyMsgs:            b.applyMsgs,
-		router:               b.router,
-		compactScheduler:     b.compactScheduler,
-		storeMeta:            b.storeMeta,
-		storeMetaLock:        b.storeMetaLock,
-		snapMgr:              b.snapMgr,
-		applyingSnapCount:    b.applyingSnapCount,
-		trans:                b.trans,
-		queuedSnaps:          make(map[uint64]struct{}),
-		pdClient:             b.pdClient,
-		engine:               b.engines,
-		kvWB:                 new(WriteBatch),
-		raftWB:               new(WriteBatch),
-		globalStats:          new(storeStats),
-		localStats:           new(storeStats),
-		tickDriverCh:         b.tickDriverCh,
-		peerEventObserver:    b.peerEventObserver,
 	}
 }
 
@@ -430,6 +339,7 @@ type workers struct {
 }
 
 type raftBatchSystem struct {
+	ctx        *GlobalContext
 	router     *router
 	workers    *workers
 	tickDriver *tickDriver
@@ -451,8 +361,12 @@ func (bs *raftBatchSystem) start(
 	if err := cfg.Validate(); err != nil {
 		return err
 	}
+	err := snapMgr.init()
+	if err != nil {
+		return err
+	}
 	wg := new(sync.WaitGroup)
-	workers := &workers{
+	bs.workers = &workers{
 		splitCheckWorker:  newWorker("split-check", wg),
 		regionWorker:      newWorker("snapshot-worker", wg),
 		raftLogGCWorker:   newWorker("raft-gc-worker", wg),
@@ -461,78 +375,75 @@ func (bs *raftBatchSystem) start(
 		computeHashWorker: newWorker("compute-hash", wg),
 		wg:                wg,
 	}
-	builder := &raftPollerBuilder{
+	bs.ctx = &GlobalContext{
 		cfg:                  cfg,
+		engine:               engines,
 		store:                meta,
-		engines:              engines,
-		router:               bs.router,
-		splitCheckScheduler:  workers.splitCheckWorker.scheduler,
-		regionScheduler:      workers.regionWorker.scheduler,
-		raftLogGCScheduler:   workers.raftLogGCWorker.scheduler,
-		compactScheduler:     workers.compactWorker.scheduler,
-		pdScheduler:          workers.pdWorker.scheduler,
-		computeHashScheduler: workers.computeHashWorker.scheduler,
-		trans:                trans,
-		pdClient:             pdClinet,
-		snapMgr:              snapMgr,
-		storeMetaLock:        new(sync.RWMutex),
 		storeMeta:            newStoreMeta(),
-		applyingSnapCount:    new(uint64),
-		tickDriverCh:         bs.tickDriver.newRegionCh,
+		storeMetaLock:        new(sync.RWMutex),
+		snapMgr:              snapMgr,
+		router:               bs.router,
+		trans:                trans,
+		pdScheduler:          bs.workers.pdWorker.scheduler,
+		regionScheduler:      bs.workers.regionWorker.scheduler,
+		computeHashScheduler: bs.workers.computeHashWorker.scheduler,
+		splitCheckScheduler:  bs.workers.splitCheckWorker.scheduler,
+		raftLogGCScheduler:   bs.workers.raftLogGCWorker.scheduler,
+		compactScheduler:     bs.workers.compactWorker.scheduler,
+		pdClient:             pdClinet,
 		peerEventObserver:    observer,
+		globalStats:          new(storeStats),
+		tickDriverCh:         bs.tickDriver.newRegionCh,
 	}
-	regionPeers, err := builder.init()
+	regionPeers, err := bs.loadPeers()
 	if err != nil {
 		return err
 	}
-	return bs.startSystem(workers, regionPeers, builder)
+
+	for _, peer := range regionPeers {
+		bs.router.register(peer)
+	}
+	bs.startWorkers(regionPeers)
+	return nil
 }
 
-func (bs *raftBatchSystem) startSystem(
-	workers *workers, regionPeers []*peerFsm, builder *raftPollerBuilder) error {
-	snapMgr := builder.snapMgr
-	err := snapMgr.init()
-	if err != nil {
-		return err
-	}
+func (bs *raftBatchSystem) startWorkers(peers []*peerFsm) {
+	ctx := bs.ctx
+	workers := bs.workers
 	router := bs.router
-	for _, peer := range regionPeers {
-		router.register(peer)
-	}
 	balancer := &balancer{
 		router: router,
 	}
-	for i := 0; i < builder.cfg.RaftWorkerCnt; i++ {
-		rw := newRaftWorker(builder, router.workerSenders[i], router)
+	for i := 0; i < ctx.cfg.RaftWorkerCnt; i++ {
+		rw := newRaftWorker(ctx, router.workerSenders[i], router)
 		balancer.workers = append(balancer.workers, rw)
 		bs.wg.Add(1)
 		go rw.run(bs.closeCh, bs.wg)
 	}
+	storeCtx := &StoreContext{GlobalContext: ctx, applyingSnapCount: new(uint64)}
 	sw := &storeWorker{
-		store: newStoreFsmDelegate(router.storeFsm, builder.build()),
+		store: newStoreFsmDelegate(router.storeFsm, storeCtx),
 	}
 	bs.wg.Add(1)
 	go sw.run(bs.closeCh, bs.wg)
 	bs.wg.Add(1)
 	go balancer.run(bs.closeCh, bs.wg)
-	router.sendStore(Msg{Type: MsgTypeStoreStart, Data: builder.store})
-	for i := 0; i < len(regionPeers); i++ {
-		regionID := regionPeers[i].peer.regionId
+	router.sendStore(Msg{Type: MsgTypeStoreStart, Data: ctx.store})
+	for i := 0; i < len(peers); i++ {
+		regionID := peers[i].peer.regionId
 		_ = router.send(regionID, Msg{RegionID: regionID, Type: MsgTypeStart})
 	}
-	engines := builder.engines
-	cfg := builder.cfg
+	engines := ctx.engine
+	cfg := ctx.cfg
 	workers.splitCheckWorker.start(newSplitCheckRunner(engines.kv.DB, router, cfg.splitCheck))
-	workers.regionWorker.start(newRegionRunner(engines, snapMgr, cfg.SnapApplyBatchSize, cfg.CleanStalePeerDelay))
+	workers.regionWorker.start(newRegionRunner(engines, ctx.snapMgr, cfg.SnapApplyBatchSize, cfg.CleanStalePeerDelay))
 	workers.raftLogGCWorker.start(&raftLogGCRunner{})
 	workers.compactWorker.start(&compactRunner{engine: engines.kv.DB})
-	pdRunner := newPDRunner(builder.store.Id, builder.pdClient, bs.router, engines.kv.DB, workers.pdWorker.scheduler)
+	pdRunner := newPDRunner(ctx.store.Id, ctx.pdClient, bs.router, engines.kv.DB, workers.pdWorker.scheduler)
 	workers.pdWorker.start(pdRunner)
 	workers.computeHashWorker.start(&computeHashRunner{router: bs.router})
-	bs.workers = workers
 	bs.wg.Add(1)
 	go bs.tickDriver.run(bs.closeCh, bs.wg) // TODO: temp workaround.
-	return nil
 }
 
 func (bs *raftBatchSystem) shutDown() {
@@ -568,7 +479,7 @@ func createRaftBatchSystem(cfg *Config) (*router, *raftBatchSystem) {
 /// Checks if the message is targeting a stale peer.
 ///
 /// Returns true means the message can be dropped silently.
-func (d *storeFsmDelegate) checkMsg(msg *rspb.RaftMessage) (bool, error) {
+func (d *storeMsgHandler) checkMsg(msg *rspb.RaftMessage) (bool, error) {
 	regionID := msg.GetRegionId()
 	fromEpoch := msg.GetRegionEpoch()
 	msgType := msg.Message.MsgType
@@ -614,7 +525,7 @@ func (d *storeFsmDelegate) checkMsg(msg *rspb.RaftMessage) (bool, error) {
 		log.Infof("tombstone peer receives a stale message. region_id:%d, from_region_epoch:%s, current_region_epoch:%s, msg_type:%s",
 			regionID, fromEpoch, regionEpoch, msgType)
 		notExist := findPeer(region, fromStoreID) == nil
-		d.ctx.handleStaleMsg(msg, regionEpoch, isVoteMsg && notExist, nil)
+		handleStaleMsg(d.ctx.trans, msg, regionEpoch, isVoteMsg && notExist, nil)
 		return true, nil
 	}
 	if fromEpoch.ConfVer == regionEpoch.ConfVer {
@@ -624,7 +535,7 @@ func (d *storeFsmDelegate) checkMsg(msg *rspb.RaftMessage) (bool, error) {
 	return false, nil
 }
 
-func (d *storeFsmDelegate) onRaftMessage(msg *rspb.RaftMessage) error {
+func (d *storeMsgHandler) onRaftMessage(msg *rspb.RaftMessage) error {
 	regionID := msg.RegionId
 	if err := d.ctx.router.send(regionID, Msg{Type: MsgTypeRaftMessage, Data: msg}); err == nil {
 		return nil
@@ -667,7 +578,7 @@ func (d *storeFsmDelegate) onRaftMessage(msg *rspb.RaftMessage) error {
 ///
 /// return false to indicate that target peer is in invalid state or
 /// doesn't exist and can't be created.
-func (d *storeFsmDelegate) maybeCreatePeer(regionID uint64, msg *rspb.RaftMessage) (bool, error) {
+func (d *storeMsgHandler) maybeCreatePeer(regionID uint64, msg *rspb.RaftMessage) (bool, error) {
 	var regionsToDestroy []uint64
 	// we may encounter a message with larger peer id, which means
 	// current peer is stale, then we should remove current peer
@@ -739,15 +650,15 @@ func destroyRegions(router *router, regionsToDestroy []uint64, toPeer *metapb.Pe
 	}
 }
 
-func (d *storeFsmDelegate) onCompactionFinished(event *rocksdb.CompactedEvent) {
+func (d *storeMsgHandler) onCompactionFinished(event *rocksdb.CompactedEvent) {
 	// TODO: not supported.
 }
 
-func (d *storeFsmDelegate) onCompactCheckTick() {
+func (d *storeMsgHandler) onCompactCheckTick() {
 	// TODO: not supported.
 }
 
-func (d *storeFsmDelegate) storeHeartbeatPD() {
+func (d *storeMsgHandler) storeHeartbeatPD() {
 	stats := new(pdpb.StoreStats)
 	stats.UsedSize = d.ctx.snapMgr.GetTotalSnapSize()
 	stats.StoreId = d.ctx.store.Id
@@ -772,12 +683,12 @@ func (d *storeFsmDelegate) storeHeartbeatPD() {
 	d.ctx.pdScheduler <- task{tp: taskTypePDStoreHeartbeat, data: storeInfo}
 }
 
-func (d *storeFsmDelegate) onPDStoreHearbeatTick() {
+func (d *storeMsgHandler) onPDStoreHearbeatTick() {
 	d.storeHeartbeatPD()
 	d.ticker.scheduleStore(StoreTickPdStoreHeartbeat)
 }
 
-func (d *storeFsmDelegate) handleSnapMgrGC() error {
+func (d *storeMsgHandler) handleSnapMgrGC() error {
 	mgr := d.ctx.snapMgr
 	snapKeys, err := mgr.ListIdleSnap()
 	if err != nil {
@@ -810,7 +721,7 @@ func (d *storeFsmDelegate) handleSnapMgrGC() error {
 	return nil
 }
 
-func (d *storeFsmDelegate) scheduleGCSnap(regionID uint64, keys []SnapKeyWithSending) error {
+func (d *storeMsgHandler) scheduleGCSnap(regionID uint64, keys []SnapKeyWithSending) error {
 	gcSnap := Msg{Type: MsgTypeGcSnap, Data: &MsgGCSnap{Snaps: keys}}
 	if d.ctx.router.send(regionID, gcSnap) != nil {
 		// The snapshot exists because MsgAppend has been rejected. So the
@@ -836,14 +747,14 @@ func (d *storeFsmDelegate) scheduleGCSnap(regionID uint64, keys []SnapKeyWithSen
 	return nil
 }
 
-func (d *storeFsmDelegate) onSnapMgrGC() {
+func (d *storeMsgHandler) onSnapMgrGC() {
 	if err := d.handleSnapMgrGC(); err != nil {
 		log.Errorf("handle snap GC failed store_id %d, err %s", d.storeFsm.id, err)
 	}
 	d.ticker.scheduleStore(StoreTickSnapGC)
 }
 
-func (d *storeFsmDelegate) onComputeHashTick() {
+func (d *storeMsgHandler) onComputeHashTick() {
 	d.ticker.scheduleStore(StoreTickConsistencyCheck)
 	if len(d.ctx.computeHashScheduler) > 0 {
 		return
@@ -868,7 +779,7 @@ func (d *storeFsmDelegate) onComputeHashTick() {
 	_ = d.ctx.router.sendRaftCommand(cmd)
 }
 
-func (d *storeFsmDelegate) findTargetRegionForComputeHash() *metapb.Region {
+func (d *storeMsgHandler) findTargetRegionForComputeHash() *metapb.Region {
 	oldest := time.Now()
 	var targetRegion *metapb.Region
 	d.ctx.storeMetaLock.RLock()
@@ -888,14 +799,14 @@ func (d *storeFsmDelegate) findTargetRegionForComputeHash() *metapb.Region {
 	return targetRegion
 }
 
-func (d *storeFsmDelegate) clearRegionSizeInRange(startKey, endKey []byte) {
+func (d *storeMsgHandler) clearRegionSizeInRange(startKey, endKey []byte) {
 	regions := d.findRegionsInRange(startKey, endKey)
 	for _, region := range regions {
 		_ = d.ctx.router.send(region.Id, NewPeerMsg(MsgTypeClearRegionSize, region.Id, nil))
 	}
 }
 
-func (d *storeFsmDelegate) findRegionsInRange(startKey, endKey []byte) []*metapb.Region {
+func (d *storeMsgHandler) findRegionsInRange(startKey, endKey []byte) []*metapb.Region {
 	d.ctx.storeMetaLock.RLock()
 	defer d.ctx.storeMetaLock.RUnlock()
 	meta := d.ctx.storeMeta

--- a/tikv/raftstore/peer.go
+++ b/tikv/raftstore/peer.go
@@ -826,13 +826,13 @@ func (p *Peer) HandleRaftReadyAppend(trans Transport, applyMsgs *applyMsgs, kvWB
 	return &ReadyICPair{Ready: ready, IC: invokeCtx}
 }
 
-func (p *Peer) PostRaftReadyAppend(trans Transport, applyMsgs *applyMsgs, ready *raft.Ready, invokeCtx *InvokeContext) *ApplySnapResult {
+func (p *Peer) PostRaftReadyPersistent(trans Transport, applyMsgs *applyMsgs, ready *raft.Ready, invokeCtx *InvokeContext) *ApplySnapResult {
 	if invokeCtx.hasSnapshot() {
 		// When apply snapshot, there is no log applied and not compacted yet.
 		p.RaftLogSizeHint = 0
 	}
 
-	applySnapResult := p.Store().PostReady(invokeCtx)
+	applySnapResult := p.Store().PostReadyPersistent(invokeCtx)
 	if applySnapResult != nil && p.Meta.GetIsLearner() {
 		// The peer may change from learner to voter after snapshot applied.
 		var pr *metapb.Peer

--- a/tikv/raftstore/peer_state.go
+++ b/tikv/raftstore/peer_state.go
@@ -91,7 +91,7 @@ type raftWorker struct {
 	pr *router
 
 	raftCh        chan Msg
-	raftCtx       *PollContext
+	raftCtx       *RaftContext
 	raftStartTime time.Time
 
 	applyCh  chan *applyBatch
@@ -102,16 +102,21 @@ type raftWorker struct {
 	closeCh           <-chan struct{}
 }
 
-func newRaftWorker(b *raftPollerBuilder, ch chan Msg, pm *router) *raftWorker {
-	pollCtx := b.build()
-	// Make one apply router for each apply context to collect apply Msgs.
-	pollCtx.applyMsgs = &applyMsgs{}
+func newRaftWorker(ctx *GlobalContext, ch chan Msg, pm *router) *raftWorker {
+	raftCtx := &RaftContext{
+		GlobalContext: ctx,
+		applyMsgs:     new(applyMsgs),
+		queuedSnaps:   make(map[uint64]struct{}),
+		kvWB:          new(WriteBatch),
+		raftWB:        new(WriteBatch),
+		localStats:    new(storeStats),
+	}
 	return &raftWorker{
 		raftCh:   ch,
-		raftCtx:  pollCtx,
+		raftCtx:  raftCtx,
 		pr:       pm,
 		applyCh:  make(chan *applyBatch, 1),
-		applyCtx: newApplyContext("", b.regionScheduler, b.engines, ch, b.cfg),
+		applyCtx: newApplyContext("", ctx.regionScheduler, ctx.engine, ch, ctx.cfg),
 	}
 }
 
@@ -149,20 +154,19 @@ func (rw *raftWorker) run(closeCh <-chan struct{}, wg *sync.WaitGroup) {
 				continue
 			}
 			peerState := rw.getPeerState(peerStateMap, msg.RegionID)
-			delegate := &peerFsmDelegate{peerFsm: peerState.peer, ctx: rw.raftCtx}
-			delegate.handleMsgs([]Msg{msg})
+			newRaftMsgHandler(peerState.peer, rw.raftCtx).HandleMsgs(msg)
 		}
 		var movePeer uint64
 		for id, peerState := range peerStateMap {
 			movePeer = id
-			delegate := &peerFsmDelegate{peerFsm: peerState.peer, ctx: rw.raftCtx}
-			batch.proposals = delegate.collectReady(batch.proposals)
+			batch.proposals = newRaftMsgHandler(peerState.peer, rw.raftCtx).HandleRaftReadyAppend(batch.proposals)
 		}
 		// Pick one peer as the candidate to be moved to other workers.
 		atomic.StoreUint64(&rw.movePeerCandidate, movePeer)
 		if rw.raftCtx.hasReady {
 			rw.handleRaftReady(peerStateMap, batch)
 		}
+		rw.raftCtx.flushLocalStats()
 		doneRaftTime := time.Now()
 		batch.iterCallbacks(func(cb *Callback) {
 			cb.raftBeginTime = rw.raftStartTime
@@ -211,7 +215,7 @@ func (rw *raftWorker) handleRaftReady(peers map[uint64]*peerState, batch *applyB
 	if len(readyRes) > 0 {
 		for _, pair := range readyRes {
 			regionID := pair.IC.RegionID
-			newPeerFsmDelegate(peers[regionID].peer, rw.raftCtx).postRaftReadyAppend(&pair.Ready, pair.IC)
+			newRaftMsgHandler(peers[regionID].peer, rw.raftCtx).PostRaftReadyPersistent(&pair.Ready, pair.IC)
 		}
 	}
 	dur := time.Since(rw.raftStartTime)
@@ -271,7 +275,7 @@ func (rw *raftWorker) runApply(wg *sync.WaitGroup) {
 
 // storeWorker runs store commands.
 type storeWorker struct {
-	store *storeFsmDelegate
+	store *storeMsgHandler
 }
 
 func (sw *storeWorker) run(closeCh <-chan struct{}, wg *sync.WaitGroup) {
@@ -283,7 +287,7 @@ func (sw *storeWorker) run(closeCh <-chan struct{}, wg *sync.WaitGroup) {
 			return
 		case msg = <-sw.store.receiver:
 		}
-		sw.store.handleMessages([]Msg{msg})
+		sw.store.handleMsg(msg)
 	}
 }
 

--- a/tikv/raftstore/peer_state.go
+++ b/tikv/raftstore/peer_state.go
@@ -116,7 +116,7 @@ func newRaftWorker(ctx *GlobalContext, ch chan Msg, pm *router) *raftWorker {
 		raftCtx:  raftCtx,
 		pr:       pm,
 		applyCh:  make(chan *applyBatch, 1),
-		applyCtx: newApplyContext("", ctx.regionScheduler, ctx.engine, ch, ctx.cfg),
+		applyCtx: newApplyContext("", ctx.regionTaskSender, ctx.engine, ch, ctx.cfg),
 	}
 }
 

--- a/tikv/raftstore/peer_storage.go
+++ b/tikv/raftstore/peer_storage.go
@@ -942,7 +942,7 @@ func RegionEqual(l, r *metapb.Region) bool {
 }
 
 // Update the memory state after ready changes are flushed to disk successfully.
-func (ps *PeerStorage) PostReady(ctx *InvokeContext) *ApplySnapResult {
+func (ps *PeerStorage) PostReadyPersistent(ctx *InvokeContext) *ApplySnapResult {
 	ps.raftState = ctx.RaftState
 	ps.applyState = ctx.ApplyState
 	ps.lastTerm = ctx.lastTerm

--- a/tikv/raftstore/resolver.go
+++ b/tikv/raftstore/resolver.go
@@ -28,7 +28,7 @@ func newResolverRunner(pdClient pd.Client) *resolverRunner {
 	}
 }
 
-func (r *resolverRunner) run(t task) {
+func (r *resolverRunner) handle(t task) {
 	data := t.data.(resolveAddrTask)
 	data.callback(r.getAddr(data.storeID))
 }

--- a/tikv/raftstore/server.go
+++ b/tikv/raftstore/server.go
@@ -57,7 +57,7 @@ func (ris *RaftInnerServer) BatchRaft(stream tikvpb.Tikv_BatchRaftServer) error 
 func (ris *RaftInnerServer) Snapshot(stream tikvpb.Tikv_SnapshotServer) error {
 	var err error
 	done := make(chan struct{})
-	ris.snapWorker.scheduler <- task{
+	ris.snapWorker.sender <- task{
 		tp: taskTypeSnapRecv,
 		data: recvSnapTask{
 			stream: stream,
@@ -135,8 +135,8 @@ func (ris *RaftInnerServer) Start(pdClient pd.Client) error {
 	ris.node = NewNode(ris.batchSystem, &ris.storeMeta, ris.raftConfig, pdClient, ris.eventObserver)
 
 	raftClient := newRaftClient(ris.raftConfig)
-	resolveSender := ris.resolveWorker.scheduler
-	trans := NewServerTransport(raftClient, ris.snapWorker.scheduler, ris.raftRouter, resolveSender)
+	resolveSender := ris.resolveWorker.sender
+	trans := NewServerTransport(raftClient, ris.snapWorker.sender, ris.raftRouter, resolveSender)
 
 	resolveRunner := newResolverRunner(pdClient)
 	ris.resolveWorker.start(resolveRunner)

--- a/tikv/raftstore/snapRunner.go
+++ b/tikv/raftstore/snapRunner.go
@@ -31,7 +31,7 @@ func newSnapRunner(snapManager *SnapManager, config *Config, router RaftRouter) 
 	}
 }
 
-func (r *snapRunner) run(t task) {
+func (r *snapRunner) handle(t task) {
 	switch t.tp {
 	case taskTypeSnapSend:
 		r.send(t.data.(sendSnapTask))

--- a/tikv/raftstore/ticker.go
+++ b/tikv/raftstore/ticker.go
@@ -43,7 +43,7 @@ func newStoreTicker(cfg *Config) *ticker {
 	return t
 }
 
-// tickClock should be called when peerFsmDelegate received tick message.
+// tickClock should be called when peerMsgHandler received tick message.
 func (t *ticker) tickClock() {
 	t.tick++
 }


### PR DESCRIPTION
- extract GlobalContext for immutable singletons.
- Separate RaftContext and StoreContext.
- Make names more consistent with their behaviors.