### PR TITLE
fix restore lockstore

### DIFF
--- a/tikv/raftstore/restore.go
+++ b/tikv/raftstore/restore.go
@@ -45,7 +45,9 @@ func RestoreLockStore(offset uint64, bundle *mvcc.DBBundle, raftDB *badger.DB) e
 			return
 		}
 	})
-	log.Info("restore lock store iterated", iterCnt, "entries")
+	if iterCnt > 0 {
+		log.Info("restore lock store iterated", iterCnt, "entries fromm offset", offset)
+	}
 	if err != nil {
 		return err
 	}

--- a/unistore-server/main.go
+++ b/unistore-server/main.go
@@ -168,13 +168,13 @@ func setupRaftInnerServer(bundle *mvcc.DBBundle, safePoint *tikv.SafePoint, pdCl
 	if err != nil {
 		log.Fatal(err)
 	}
+	var offset uint64
 	if meta != nil {
-		offset := binary.LittleEndian.Uint64(meta)
-		err = raftstore.RestoreLockStore(offset, bundle, raftDB)
-		if err != nil {
-			log.Fatal(err)
-		}
-		log.Info("restored lock store from offset", offset)
+		offset = binary.LittleEndian.Uint64(meta)
+	}
+	err = raftstore.RestoreLockStore(offset, bundle, raftDB)
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	engines := raftstore.NewEngines(bundle, raftDB, kvPath, raftPath)


### PR DESCRIPTION
Fixes https://github.com/ngaut/unistore/issues/277

When unistore is killed soon after started, there is not lockstore dump file, we still need to restore the lockStore from 0 offset.