### PR TITLE
[RPC] Add keepalive for stream connection

### DIFF
--- a/tikv/raftstore/raft_client.go
+++ b/tikv/raftstore/raft_client.go
@@ -22,8 +22,9 @@ func newRaftConn(addr string, cfg *Config) (*raftConn, error) {
 	cc, err := grpc.Dial(addr, grpc.WithInsecure(),
 		grpc.WithInitialWindowSize(int32(cfg.GrpcInitialWindowSize)),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:    cfg.GrpcKeepAliveTime,
-			Timeout: cfg.GrpcKeepAliveTimeout,
+			Time:                cfg.GrpcKeepAliveTime,
+			Timeout:             cfg.GrpcKeepAliveTimeout,
+			PermitWithoutStream: true,
 		}))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Solving issue #287 

Reduce the server closing stream connection times and related error logs printing, make the raft client connection keepalive take effect 