### PR TITLE
[txn] Complete CheckTxnStatus related logic, and port tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/pierrec/lz4 v2.0.5+incompatible
 	github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8
 	github.com/pingcap/errors v0.11.4
-	github.com/pingcap/kvproto v0.0.0-20191030021250-51b332bcb20b
+	github.com/pingcap/kvproto v0.0.0-20191121022655-4c654046831d
 	github.com/pingcap/parser v0.0.0-20190903084634-0daf3f706c76
 	github.com/pingcap/tidb v1.1.0-beta.0.20190904060835-0872b65ff1f9
 	github.com/pingcap/tipb v0.0.0-20191008064422-018b2fadf414

--- a/go.sum
+++ b/go.sum
@@ -187,13 +187,11 @@ github.com/pingcap/failpoint v0.0.0-20190512135322-30cc7431d99c h1:hvQd3aOLKLF7x
 github.com/pingcap/failpoint v0.0.0-20190512135322-30cc7431d99c/go.mod h1:DNS3Qg7bEDhU6EXNHF+XSv/PGznQaMJ5FWvctpm6pQI=
 github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e h1:P73/4dPCL96rGrobssy1nVy2VaVpNCuLpCbr+FEaTA8=
 github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
-github.com/pingcap/kvproto v0.0.0-20190227013052-e71ca0165a5f h1:4hYEuFIwCBrrf0OLGX7lbVmhYzOiNCFUf6ldjo21h7Q=
 github.com/pingcap/kvproto v0.0.0-20190227013052-e71ca0165a5f/go.mod h1:QMdbTAXCHzzygQzqcG9uVUgU2fKeSN1GmfMiykdSzzY=
 github.com/pingcap/kvproto v0.0.0-20190516013202-4cf58ad90b6c/go.mod h1:QMdbTAXCHzzygQzqcG9uVUgU2fKeSN1GmfMiykdSzzY=
-github.com/pingcap/kvproto v0.0.0-20190821201150-798d27658fae h1:WR4d5ga8zXT+QDWYFzzyA+PJMMszR0kQxyYMh6dvHPg=
 github.com/pingcap/kvproto v0.0.0-20190821201150-798d27658fae/go.mod h1:QMdbTAXCHzzygQzqcG9uVUgU2fKeSN1GmfMiykdSzzY=
-github.com/pingcap/kvproto v0.0.0-20191030021250-51b332bcb20b h1:ftvwDk/eXlpQkQoZdJfkrSGJiyPWohyfkFcpHlChaK8=
-github.com/pingcap/kvproto v0.0.0-20191030021250-51b332bcb20b/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
+github.com/pingcap/kvproto v0.0.0-20191121022655-4c654046831d h1:aH7ZFzWEyBgUtG/YlLOU7pIx++PqtXlRT7zpHcEf2Rg=
+github.com/pingcap/kvproto v0.0.0-20191121022655-4c654046831d/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
 github.com/pingcap/log v0.0.0-20190214045112-b37da76f67a7/go.mod h1:xsfkWVaFVV5B8e1K9seWfyJWFrIhbtUTAD8NV1Pq3+w=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596 h1:t2OQTpPJnrPDGlvA+3FwJptMTt6MEPdzK1Wt99oaefQ=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=

--- a/lockstore/lockstore.go
+++ b/lockstore/lockstore.go
@@ -7,6 +7,8 @@ import (
 	"sync/atomic"
 	"time"
 	"unsafe"
+
+	"github.com/ngaut/log"
 )
 
 // MemStore is a skiplist variant used to store lock.
@@ -251,6 +253,7 @@ func (ls *MemStore) Insert(key []byte, v []byte) bool {
 		prev[i], next[i], exists = ls.findSpliceForLevel(ls.getArena(), key, prev[i+1], i)
 		if exists {
 			// The save key already exists.
+			log.Error("the save key already exists key=%v", key)
 			return false
 		}
 	}

--- a/tikv/errors.go
+++ b/tikv/errors.go
@@ -80,3 +80,13 @@ type ErrCommitExpire struct {
 func (e *ErrCommitExpire) Error() string {
 	return "commit expired"
 }
+
+// ErrTxnNotFound is returned if the required txn info not found on storage
+type ErrTxnNotFound struct {
+	StartTS    uint64
+	PrimaryKey []byte
+}
+
+func (e *ErrTxnNotFound) Error() string {
+	return "txn not found"
+}

--- a/tikv/errors.go
+++ b/tikv/errors.go
@@ -68,3 +68,15 @@ type ErrConflict struct {
 func (e *ErrConflict) Error() string {
 	return "write conflict"
 }
+
+// ErrCommitExpire is returned when commit key commitTs smaller than lock.MinCommitTs
+type ErrCommitExpire struct {
+	StartTs     uint64
+	CommitTs    uint64
+	MinCommitTs uint64
+	Key         []byte
+}
+
+func (e *ErrCommitExpire) Error() string {
+	return "commit expired"
+}

--- a/tikv/mvcc.go
+++ b/tikv/mvcc.go
@@ -248,7 +248,7 @@ func (store *MVCCStore) TxnHeartBeat(reqCtx *requestCtx, req *kvrpcpb.TxnHeartBe
 	return 0, errors.New("lock doesn't exists")
 }
 
-// CheckTxnStatus returns the txn status based request primary key
+// CheckTxnStatus returns the txn status based on request primary key txn info
 func (store *MVCCStore) CheckTxnStatus(reqCtx *requestCtx,
 	req *kvrpcpb.CheckTxnStatusRequest) (ttl, commitTS uint64, action kvrpcpb.Action, err error) {
 	hashVals := keysToHashVals(req.PrimaryKey)

--- a/tikv/mvcc.go
+++ b/tikv/mvcc.go
@@ -248,8 +248,9 @@ func (store *MVCCStore) TxnHeartBeat(reqCtx *requestCtx, req *kvrpcpb.TxnHeartBe
 	return 0, errors.New("lock doesn't exists")
 }
 
+// CheckTxnStatus returns the txn status based request primary key
 func (store *MVCCStore) CheckTxnStatus(reqCtx *requestCtx,
-	req *kvrpcpb.CheckTxnStatusRequest) (ttl, commitTS uint64, err error) {
+	req *kvrpcpb.CheckTxnStatusRequest) (ttl, commitTS uint64, action kvrpcpb.Action, err error) {
 	hashVals := keysToHashVals(req.PrimaryKey)
 	regCtx := reqCtx.regCtx
 	regCtx.AcquireLatches(hashVals)
@@ -260,11 +261,12 @@ func (store *MVCCStore) CheckTxnStatus(reqCtx *requestCtx,
 		// If the lock has already outdated, clean up it.
 		if uint64(oracle.ExtractPhysical(lock.StartTS))+uint64(lock.TTL) < uint64(oracle.ExtractPhysical(req.CurrentTs)) {
 			batch.Rollback(req.PrimaryKey, true)
-			return 0, 0, store.dbWriter.Write(batch)
+			return 0, 0, kvrpcpb.Action_TTLExpireRollback, store.dbWriter.Write(batch)
 		}
 		// If this is a large transaction and the lock is active, push forward the minCommitTS.
 		// lock.minCommitTS == 0 may be a secondary lock, or not a large transaction.
 		if lock.MinCommitTS > 0 {
+			action = kvrpcpb.Action_MinCommitTSPushed
 			// We *must* guarantee the invariance lock.minCommitTS >= callerStartTS + 1
 			if lock.MinCommitTS < req.CallerStartTs+1 {
 				lock.MinCommitTS = req.CallerStartTs + 1
@@ -278,19 +280,39 @@ func (store *MVCCStore) CheckTxnStatus(reqCtx *requestCtx,
 				batch.PessimisticRollback(req.PrimaryKey)
 				batch.PessimisticLock(req.PrimaryKey, lock)
 				if err = store.dbWriter.Write(batch); err != nil {
-					return 0, 0, err
+					return 0, 0, action, err
 				}
 			}
 		}
-		return uint64(lock.TTL), 0, nil
+		return uint64(lock.TTL), 0, action, nil
 	}
+
+	// The current transaction lock not exists, check the transaction commit info
 	commitTS, err = store.checkCommitted(reqCtx.getDBReader(), req.PrimaryKey, req.LockTs)
-	if commitTS == 0 {
-		// TODO: this is temporary solution. we should be able to check the status without rollback.
+	if commitTS > 0 {
+		return
+	}
+	// Check if the transaction already rollbacked
+	if len(store.rollbackStore.Get(req.PrimaryKey, nil)) > 0 {
+		action = kvrpcpb.Action_NoAction
+		return
+	}
+	// If current transaction is not prewritted before, it may be pessimistic lock.
+	// When pessimistic txn rollback statement, it may not leave a 'rollbacked' tombstone.
+	// Or maybe caused by concurrent prewrite operation.
+	// Especially in the non-block reading case, the secondary lock is likely to be
+	// written before the primary lock.
+	// Currently client will always set this flag to true when resolving locks
+	if req.RollbackIfNotExist {
 		batch.Rollback(req.PrimaryKey, false)
 		err = store.dbWriter.Write(batch)
+		action = kvrpcpb.Action_LockNotExistRollback
+		return
 	}
-	return
+	return 0, 0, action, &ErrTxnNotFound{
+		PrimaryKey: req.PrimaryKey,
+		StartTS:    req.LockTs,
+	}
 }
 
 func (store *MVCCStore) handleCheckPessimisticErr(startTS uint64, err error, isFirstLock bool) (*lockwaiter.Waiter, error) {

--- a/tikv/mvcc_test.go
+++ b/tikv/mvcc_test.go
@@ -97,7 +97,8 @@ func PessimisticLock(pk []byte, key []byte, startTs uint64, lockTTL uint64, forU
 }
 
 // PrewriteOptimistic raises optimistic prewrite requests on store
-func PrewriteOptimistic(pk []byte, key []byte, value []byte, startTs uint64, lockTTL uint64, store *TestStore) error {
+func PrewriteOptimistic(pk []byte, key []byte, value []byte, startTs uint64, lockTTL uint64,
+	minCommitTs uint64, store *TestStore) error {
 	var err error
 	mut := &kvrpcpb.Mutation{
 		Op:    kvrpcpb.Op_Put,
@@ -115,6 +116,7 @@ func PrewriteOptimistic(pk []byte, key []byte, value []byte, startTs uint64, loc
 		PrimaryLock:  pk,
 		StartVersion: startTs,
 		LockTtl:      lockTTL,
+		MinCommitTs:  minCommitTs,
 	}
 	err = store.MvccStore.prewriteOptimistic(reqCtx, prewriteReq.Mutations, prewriteReq)
 	return err
@@ -181,8 +183,27 @@ func RollBackKey(key []byte, startTs uint64, store *TestStore) error {
 	return err
 }
 
-func MustPrewriteOptimistic(pk []byte, key []byte, value []byte, startTs uint64, lockTTL uint64, store *TestStore, c *C) {
-	c.Assert(PrewriteOptimistic(pk, key, value, startTs, lockTTL, store), IsNil)
+func CheckTxnStatus(pk []byte, lockTs uint64, callerStartTs uint64,
+	currentTs uint64, store *TestStore) (uint64, uint64, error) {
+	reqCtx := &requestCtx{
+		regCtx: &regionCtx{
+			latches: make(map[uint64]*sync.WaitGroup),
+		},
+		svr: store.Svr,
+	}
+	req := &kvrpcpb.CheckTxnStatusRequest{
+		PrimaryKey:    pk,
+		LockTs:        lockTs,
+		CallerStartTs: callerStartTs,
+		CurrentTs:     currentTs,
+	}
+	resTTL, resCommitTs, err := store.MvccStore.CheckTxnStatus(reqCtx, req)
+	return resTTL, resCommitTs, err
+}
+
+func MustPrewriteOptimistic(pk []byte, key []byte, value []byte, startTs uint64, lockTTL uint64,
+	minCommitTs uint64, store *TestStore, c *C) {
+	c.Assert(PrewriteOptimistic(pk, key, value, startTs, lockTTL, minCommitTs, store), IsNil)
 	reqCtx := &requestCtx{
 		regCtx: &regionCtx{
 			latches: make(map[uint64]*sync.WaitGroup),
@@ -237,7 +258,7 @@ func (s *testMvccSuite) TestBasicOptimistic(c *C) {
 	key1 := []byte("key1")
 	val1 := []byte("val1")
 	ttl := uint64(200)
-	MustPrewriteOptimistic(key1, key1, val1, 1, ttl, store, c)
+	MustPrewriteOptimistic(key1, key1, val1, 1, ttl, 0, store, c)
 	MustCommitKey(key1, val1, 1, 2, store, c)
 	// Read using smaller ts results in nothing
 	getVal, err := KvGet(key1, 1, store)
@@ -291,14 +312,156 @@ func (s *testMvccSuite) TestRollback(c *C) {
 	startTs := uint64(1)
 	lockTTL := uint64(100)
 	// Add a Rollback whose start ts is 1.
-	MustPrewriteOptimistic(key, key, val, startTs, lockTTL, store, c)
+	MustPrewriteOptimistic(key, key, val, startTs, lockTTL, 0, store, c)
 	MustRollbackKey(key, startTs, store, c)
 
-	MustPrewriteOptimistic(key, key, val, startTs+1, lockTTL, store, c)
+	MustPrewriteOptimistic(key, key, val, startTs+1, lockTTL, 0, store, c)
 	MustRollbackKey(key, startTs+1, store, c)
 	var buf []byte
 	// Rollback entry still exits in rollbackStore if no rollbackGC
 	rollbackKey := mvcc.EncodeRollbackKey(buf, key, startTs)
 	res := store.MvccStore.rollbackStore.Get(rollbackKey, nil)
 	c.Assert(bytes.Compare(res, []byte{0}), Equals, 0)
+}
+
+func (s *testMvccSuite) TestOverwritePessimisitcLock(c *C) {
+	var err error
+	store, err := NewTestStore("OverWritePessimisticData", "OverWritePessimisticLog")
+	c.Assert(err, IsNil)
+	defer CleanTestStore(store)
+
+	key := []byte("key")
+	startTs := uint64(1)
+	lockTTL := uint64(100)
+	forUpdateTs := uint64(100)
+	// pessimistic lock one key
+	_, err = PessimisticLock(key, key, startTs, lockTTL, forUpdateTs, true, store)
+	c.Assert(err, IsNil)
+
+	reqCtx := &requestCtx{
+		regCtx: &regionCtx{
+			latches: make(map[uint64]*sync.WaitGroup),
+		},
+		svr: store.Svr,
+	}
+	lock := store.MvccStore.getLock(reqCtx, key)
+	c.Assert(lock.ForUpdateTS, Equals, forUpdateTs)
+
+	// pessimistic lock this key again using larger forUpdateTs
+	_, err = PessimisticLock(key, key, startTs, lockTTL, forUpdateTs+7, true, store)
+	c.Assert(err, IsNil)
+	reqCtx.buf = nil
+	lock2 := store.MvccStore.getLock(reqCtx, key)
+	c.Assert(lock2.ForUpdateTS, Equals, forUpdateTs+7)
+
+	// pessimistic lock one key using smaller forUpdateTsTs
+	_, err = PessimisticLock(key, key, startTs, lockTTL, forUpdateTs-7, true, store)
+	c.Assert(err, IsNil)
+	reqCtx.buf = nil
+	lock3 := store.MvccStore.getLock(reqCtx, key)
+	c.Assert(lock3.ForUpdateTS, Equals, forUpdateTs+7)
+}
+
+func (s *testMvccSuite) TestCheckTxnStatus(c *C) {
+	var err error
+	store, err := NewTestStore("CheckTxnStatusDB", "CheckTxnStatusLog")
+	c.Assert(err, IsNil)
+	defer CleanTestStore(store)
+
+	var resTTL, resCommitTs uint64
+	pk := []byte("pk")
+	startTs := uint64(1)
+	callerStartTs := uint64(3)
+	currentTs := uint64(5)
+
+	// Try to check a not exist thing.
+	resTTL, resCommitTs, err = CheckTxnStatus(pk, startTs, callerStartTs, currentTs, store)
+	c.Assert(resTTL, Equals, uint64(0))
+	c.Assert(resCommitTs, Equals, uint64(0))
+	c.Assert(err, IsNil)
+
+	// Using same startTs, prewrite will fail, since checkTxnStatus has rollbacked the key
+	val := []byte("val")
+	lockTTL := uint64(100)
+	minCommitTs := uint64(20)
+	err = PrewriteOptimistic(pk, pk, val, startTs, lockTTL, minCommitTs, store)
+	c.Assert(err, Equals, ErrAlreadyRollback)
+
+	// Prewrite a large txn
+	startTs = 2
+	MustPrewriteOptimistic(pk, pk, val, startTs, lockTTL, minCommitTs, store, c)
+	resTTL, resCommitTs, err = CheckTxnStatus(pk, startTs, callerStartTs, currentTs, store)
+	c.Assert(resTTL, Equals, lockTTL)
+	c.Assert(resCommitTs, Equals, uint64(0))
+	c.Assert(err, IsNil)
+
+	// Update min_commit_ts to current_ts. minCommitTs 20 -> 25
+	newCallerTs := uint64(25)
+	resTTL, resCommitTs, err = CheckTxnStatus(pk, startTs, newCallerTs, newCallerTs, store)
+	c.Assert(resTTL, Equals, lockTTL)
+	c.Assert(resCommitTs, Equals, uint64(0))
+	c.Assert(err, IsNil)
+	reqCtx := &requestCtx{
+		regCtx: &regionCtx{
+			latches: make(map[uint64]*sync.WaitGroup),
+		},
+		svr: store.Svr,
+	}
+	lock := store.MvccStore.getLock(reqCtx, pk)
+	c.Assert(lock.StartTS, Equals, startTs)
+	c.Assert(uint64(lock.TTL), Equals, lockTTL)
+	c.Assert(lock.MinCommitTS, Equals, newCallerTs+1)
+
+	// When caller_start_ts < lock.min_commit_ts, here 25 < 26, no need to update it.
+	resTTL, resCommitTs, err = CheckTxnStatus(pk, startTs, newCallerTs, newCallerTs, store)
+	c.Assert(resTTL, Equals, lockTTL)
+	c.Assert(resCommitTs, Equals, uint64(0))
+	c.Assert(err, IsNil)
+	reqCtx.buf = nil
+	lock = store.MvccStore.getLock(reqCtx, pk)
+	c.Assert(lock.StartTS, Equals, startTs)
+	c.Assert(uint64(lock.TTL), Equals, lockTTL)
+	c.Assert(lock.MinCommitTS, Equals, newCallerTs+1)
+
+	// current_ts(25) < lock.min_commit_ts(26) < caller_start_ts(35)
+	currentTs = uint64(25)
+	newCallerTs = 35
+	resTTL, resCommitTs, err = CheckTxnStatus(pk, startTs, newCallerTs, currentTs, store)
+	c.Assert(resTTL, Equals, lockTTL)
+	c.Assert(resCommitTs, Equals, uint64(0))
+	c.Assert(err, IsNil)
+	reqCtx.buf = nil
+	lock = store.MvccStore.getLock(reqCtx, pk)
+	c.Assert(lock.StartTS, Equals, startTs)
+	c.Assert(uint64(lock.TTL), Equals, lockTTL)
+	c.Assert(lock.MinCommitTS, Equals, newCallerTs+1) // minCommitTS updated to 36
+
+	// current_ts is max value 40, but no effect since caller_start_ts is smaller than minCommitTs
+	currentTs = uint64(40)
+	resTTL, resCommitTs, err = CheckTxnStatus(pk, startTs, newCallerTs, currentTs, store)
+	c.Assert(resTTL, Equals, lockTTL)
+	c.Assert(resCommitTs, Equals, uint64(0))
+	c.Assert(err, IsNil)
+	reqCtx.buf = nil
+	lock = store.MvccStore.getLock(reqCtx, pk)
+	c.Assert(lock.StartTS, Equals, startTs)
+	c.Assert(uint64(lock.TTL), Equals, lockTTL)
+	c.Assert(lock.MinCommitTS, Equals, newCallerTs+1) // minCommitTS updated to 36
+
+	// commit this key, commitTs(35) smaller than minCommitTs(36)
+	commitTs := uint64(35)
+	err = CommitKey(pk, startTs, commitTs, store)
+	c.Assert(err, NotNil)
+
+	// commit this key, using correct commitTs
+	commitTs = uint64(41)
+	MustCommitKey(pk, val, startTs, commitTs, store, c)
+
+	// check committed txn status
+	currentTs = uint64(42)
+	newCallerTs = uint64(42)
+	resTTL, resCommitTs, err = CheckTxnStatus(pk, startTs, newCallerTs, currentTs, store)
+	c.Assert(resTTL, Equals, uint64(0))
+	c.Assert(resCommitTs, Equals, uint64(41))
+	c.Assert(err, IsNil)
 }

--- a/tikv/server.go
+++ b/tikv/server.go
@@ -280,8 +280,8 @@ func (svr *Server) KvCheckTxnStatus(ctx context.Context, req *kvrpcpb.CheckTxnSt
 	if reqCtx.regErr != nil {
 		return &kvrpcpb.CheckTxnStatusResponse{RegionError: reqCtx.regErr}, nil
 	}
-	lockTTL, commitTS, err := svr.mvccStore.CheckTxnStatus(reqCtx, req)
-	resp := &kvrpcpb.CheckTxnStatusResponse{LockTtl: lockTTL, CommitVersion: commitTS}
+	lockTTL, commitTS, action, err := svr.mvccStore.CheckTxnStatus(reqCtx, req)
+	resp := &kvrpcpb.CheckTxnStatusResponse{LockTtl: lockTTL, CommitVersion: commitTS, Action: action}
 	resp.Error, resp.RegionError = convertToPBError(err)
 	return resp, nil
 }
@@ -666,6 +666,13 @@ func convertToKeyError(err error) *kvrpcpb.KeyError {
 				AttemptedCommitTs: x.CommitTs,
 				Key:               x.Key,
 				MinCommitTs:       x.MinCommitTs,
+			},
+		}
+	case *ErrTxnNotFound:
+		return &kvrpcpb.KeyError{
+			TxnNotFound: &kvrpcpb.TxnNotFound{
+				StartTs:    x.StartTS,
+				PrimaryKey: x.PrimaryKey,
 			},
 		}
 	default:

--- a/tikv/server.go
+++ b/tikv/server.go
@@ -659,6 +659,15 @@ func convertToKeyError(err error) *kvrpcpb.KeyError {
 				DeadlockKeyHash: x.DeadlockKeyHash,
 			},
 		}
+	case *ErrCommitExpire:
+		return &kvrpcpb.KeyError{
+			CommitTsExpired: &kvrpcpb.CommitTsExpired{
+				StartTs:           x.StartTs,
+				AttemptedCommitTs: x.CommitTs,
+				Key:               x.Key,
+				MinCommitTs:       x.MinCommitTs,
+			},
+		}
 	default:
 		return &kvrpcpb.KeyError{
 			Abort: err.Error(),


### PR DESCRIPTION
1. Let the `minCommitTs` fields take effect for prewrite and commit
2. Complete the `CheckTxnStatus` API related logic, add `Action` and `RollbackIfNotExists` field, port some tests from tikv

coverage(tikv 21.9 -> 23.8)