### PR TITLE
[txn]Do update the lockstore when rollbacking pessimistic lock

### DIFF
--- a/tikv/raftstore/peer.go
+++ b/tikv/raftstore/peer.go
@@ -716,10 +716,11 @@ func (p *Peer) OnRoleChanged(observer PeerEventObserver, ready *raft.Ready) {
 			if !p.PendingRemove {
 				p.leaderChecker.term.Store(p.Term())
 			}
+			observer.OnRoleChange(p.getEventContext().RegionId, ss.RaftState)
 		} else if ss.RaftState == raft.StateFollower {
 			p.leaderLease.Expire()
+			observer.OnRoleChange(p.getEventContext().RegionId, ss.RaftState)
 		}
-		observer.OnRoleChange(p.getEventContext().RegionId, ss.RaftState)
 	}
 }
 


### PR DESCRIPTION
Issue #297  

Need to update the lockStore when rollbacking pessimistic locks

Jepsen test command
```
lein run test --workload=bank-multitable --read-lock=update --time-limit 120 --concurrency 2n --txn-mode "pessimistic"
```

Master branch jepsen test
```
wc -l history.txt 
600 history.txt
grep -P ":ok.*transfer" history.edn  | wc -l
3
```

Running jepsen test with this diff
```
wc -l history.txt 
3410 history.txt
grep -P ":ok.*transfer" history.edn  | wc -l
642
```