### PR TITLE
[storage] support mvcc get by key

### DIFF
--- a/tikv/dbreader/db_reader.go
+++ b/tikv/dbreader/db_reader.go
@@ -81,16 +81,12 @@ func (r *DBReader) getKeyWithMeta(key []byte, isRowKey bool, startTs uint64, mvc
 			}
 		}
 		curRecord := &kvrpcpb.MvccWrite{
-			Type:     kvrpcpb.Op_Put,
-			StartTs:  dbUsrMeta.StartTS(),
-			CommitTs: dbUsrMeta.CommitTS(),
-		}
-		curVal := &kvrpcpb.MvccValue{StartTs: curRecord.StartTs, Value: val}
-		if len(curRecord.ShortValue) <= mvcc.ShortValueMaxLen {
-			curRecord.ShortValue = val
+			Type:       kvrpcpb.Op_Put,
+			StartTs:    dbUsrMeta.StartTS(),
+			CommitTs:   dbUsrMeta.CommitTS(),
+			ShortValue: val,
 		}
 		mvccInfo.Writes = append(mvccInfo.Writes, curRecord)
-		mvccInfo.Values = append(mvccInfo.Values, curVal)
 	}
 	return nil
 }
@@ -117,16 +113,12 @@ func (r *DBReader) getOldKeysWithMeta(key []byte, startTs uint64, isRowKey bool,
 			}
 		}
 		curRecord := &kvrpcpb.MvccWrite{
-			Type:     kvrpcpb.Op_Put,
-			StartTs:  oldUsrMeta.StartTS(),
-			CommitTs: commitTs,
-		}
-		valueItem := &kvrpcpb.MvccValue{StartTs: curRecord.StartTs, Value: val}
-		if len(curRecord.ShortValue) <= mvcc.ShortValueMaxLen {
-			curRecord.ShortValue = val
+			Type:       kvrpcpb.Op_Put,
+			StartTs:    oldUsrMeta.StartTS(),
+			CommitTs:   commitTs,
+			ShortValue: val,
 		}
 		mvccInfo.Writes = append(mvccInfo.Writes, curRecord)
-		mvccInfo.Values = append(mvccInfo.Values, valueItem)
 	}
 
 	return nil

--- a/tikv/dbreader/db_reader.go
+++ b/tikv/dbreader/db_reader.go
@@ -106,7 +106,7 @@ func (r *DBReader) getOldKeysWithMeta(key []byte, startTs uint64, isRowKey bool,
 		if err != nil {
 			return err
 		}
-		val, err := item.Value()
+		val, err := item.ValueCopy(nil)
 		if err != nil {
 			return err
 		}

--- a/tikv/dbreader/db_reader.go
+++ b/tikv/dbreader/db_reader.go
@@ -70,7 +70,7 @@ func (r *DBReader) getKeyWithMeta(key []byte, isRowKey bool, startTs uint64, mvc
 	}
 	dbUsrMeta := mvcc.DBUserMeta(item.UserMeta())
 	if dbUsrMeta.CommitTS() <= startTs {
-		val, err := item.Value()
+		val, err := item.ValueCopy(nil)
 		if err != nil {
 			return err
 		}

--- a/tikv/dbreader/db_reader.go
+++ b/tikv/dbreader/db_reader.go
@@ -70,12 +70,18 @@ func (r *DBReader) getKeyWithMeta(key []byte, isRowKey bool, startTs uint64, mvc
 	}
 	dbUsrMeta := mvcc.DBUserMeta(item.UserMeta())
 	if dbUsrMeta.CommitTS() <= startTs {
-		val, err := item.ValueCopy(nil)
-		if err != nil {
-			return err
-		}
+		var val []byte
 		if isRowKey {
+			val, err = item.Value()
+			if err != nil {
+				return err
+			}
 			val, err = rowcodec.RowToOldRow(val, nil)
+			if err != nil {
+				return err
+			}
+		} else {
+			val, err = item.ValueCopy(nil)
 			if err != nil {
 				return err
 			}
@@ -102,12 +108,18 @@ func (r *DBReader) getOldKeysWithMeta(key []byte, startTs uint64, isRowKey bool,
 		if err != nil {
 			return err
 		}
-		val, err := item.ValueCopy(nil)
-		if err != nil {
-			return err
-		}
+		var val []byte
 		if isRowKey {
+			val, err = item.Value()
+			if err != nil {
+				return err
+			}
 			val, err = rowcodec.RowToOldRow(val, nil)
+			if err != nil {
+				return err
+			}
+		} else {
+			val, err = item.ValueCopy(nil)
 			if err != nil {
 				return err
 			}

--- a/tikv/mvcc.go
+++ b/tikv/mvcc.go
@@ -932,14 +932,9 @@ func (store *MVCCStore) MvccGetByKey(reqCtx *requestCtx, key []byte) (*kvrpcpb.M
 			Type:       kvrpcpb.Op_Rollback,
 			StartTs:    rollbackTs,
 			CommitTs:   rollbackTs,
-			ShortValue: it.Value(),
-		}
-		curVal := &kvrpcpb.MvccValue{
-			StartTs: rollbackTs,
-			Value:   it.Value(),
+			ShortValue: safeCopy(it.Value()),
 		}
 		mvccInfo.Writes = append(mvccInfo.Writes, curRecord)
-		mvccInfo.Values = append(mvccInfo.Values, curVal)
 	}
 	return mvccInfo, nil
 }

--- a/tikv/mvcc/mvcc.go
+++ b/tikv/mvcc/mvcc.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"unsafe"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/util/codec"
 )
 
@@ -107,6 +108,18 @@ func EncodeOldKey(key []byte, ts uint64) []byte {
 	ret := codec.EncodeUintDesc(b, ts)
 	ret[0]++
 	return ret
+}
+
+// DecodeOldKeyCommitTs decodes commitTs from encoded old key
+func DecodeOldKeyCommitTs(key []byte) (uint64, error) {
+	if len(key) < 8 {
+		return 0, errors.Errorf("invalid input key=%v length=%d less than 8 bytes", key, len(key))
+	}
+	_, res, err := codec.DecodeUintDesc(key[len(key)-8:])
+	if err != nil {
+		return 0, err
+	}
+	return res, nil
 }
 
 // EncodeRollbackKey encodes a rollback key.

--- a/tikv/mvcc/tikv.go
+++ b/tikv/mvcc/tikv.go
@@ -43,7 +43,7 @@ func ParseWriteCFValue(data []byte) (wv WriteCFValue, err error) {
 const (
 	shortValuePrefix = 'v'
 	forUpdatePrefix  = 'f'
-	shortValueMaxLen = 64
+	ShortValueMaxLen = 64
 )
 
 // EncodeWriteCFValue accepts a write cf parameters and return the encoded bytes data.
@@ -77,7 +77,7 @@ func EncodeLockCFValue(lock *MvccLock) ([]byte, []byte) {
 	var longValue []byte
 	data = codec.EncodeUvarint(codec.EncodeCompactBytes(data, lock.Primary), lock.StartTS)
 	data = codec.EncodeUvarint(data, uint64(lock.TTL))
-	if len(lock.Value) <= shortValueMaxLen {
+	if len(lock.Value) <= ShortValueMaxLen {
 		if len(lock.Value) != 0 {
 			data = append(data, byte(shortValuePrefix), byte(len(lock.Value)))
 			data = append(data, lock.Value...)

--- a/tikv/mvcc_test.go
+++ b/tikv/mvcc_test.go
@@ -512,7 +512,7 @@ func (s *testMvccSuite) TestMvccGetByKey(c *C) {
 	c.Assert(len(res.Values), Equals, 2)
 
 	// prewrite and then rollback
-	// Add a Rollback whose start ts is 1.
+	// Add a Rollback whose start ts is 5.
 	startTs3 := uint64(5)
 	rollbackVal := []byte("rollbackVal")
 	MustPrewriteOptimistic(pk, pk, rollbackVal, startTs3, lockTTL, 0, store, c)

--- a/tikv/mvcc_test.go
+++ b/tikv/mvcc_test.go
@@ -474,3 +474,70 @@ func (s *testMvccSuite) TestCheckTxnStatus(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(action, Equals, kvrpcpb.Action_NoAction)
 }
+
+func (s *testMvccSuite) TestMvccGetByKey(c *C) {
+	var err error
+	store, err := NewTestStore("TestMvccGetByKey", "TestMvccGetByKey")
+	c.Assert(err, IsNil)
+	defer CleanTestStore(store)
+
+	lockTTL := uint64(100)
+	pk := []byte("pk")
+	pkVal := []byte("pkVal")
+	startTs1 := uint64(1)
+	commitTs1 := uint64(2)
+	// write one record
+	MustPrewriteOptimistic(pk, pk, pkVal, startTs1, lockTTL, 0, store, c)
+	MustCommitKey(pk, pkVal, startTs1, commitTs1, store, c)
+
+	// update this record
+	startTs2 := uint64(3)
+	commitTs2 := uint64(4)
+	newVal := []byte("aba")
+	MustPrewriteOptimistic(pk, pk, newVal, startTs2, lockTTL, 0, store, c)
+	MustCommitKey(pk, newVal, startTs2, commitTs2, store, c)
+
+	// read using mvcc
+	reqCtx := &requestCtx{
+		regCtx: &regionCtx{
+			latches: make(map[uint64]*sync.WaitGroup),
+		},
+		svr: store.Svr,
+	}
+	var res *kvrpcpb.MvccInfo
+	res, err = store.MvccStore.MvccGetByKey(reqCtx, pk)
+	c.Assert(err, IsNil)
+	c.Assert(len(res.Writes), Equals, 2)
+	c.Assert(len(res.Values), Equals, 2)
+
+	// put empty value
+	startTs3 := uint64(5)
+	commitTs3 := uint64(6)
+	emptyVal := []byte("")
+	MustPrewriteOptimistic(pk, pk, emptyVal, startTs3, lockTTL, 0, store, c)
+	MustCommitKey(pk, emptyVal, startTs3, commitTs3, store, c)
+
+	// read using mvcc
+	reqCtx.reader = nil
+	res, err = store.MvccStore.MvccGetByKey(reqCtx, pk)
+	c.Assert(err, IsNil)
+	c.Assert(len(res.Writes), Equals, 3)
+	c.Assert(len(res.Values), Equals, 3)
+	c.Assert(res.Writes[2].StartTs, Equals, startTs1)
+	c.Assert(res.Writes[2].CommitTs, Equals, commitTs1)
+	c.Assert(bytes.Compare(res.Writes[2].ShortValue, pkVal), Equals, 0)
+	c.Assert(res.Values[2].StartTs, Equals, startTs1)
+	c.Assert(bytes.Compare(res.Values[2].Value, pkVal), Equals, 0)
+
+	c.Assert(res.Writes[1].StartTs, Equals, startTs2)
+	c.Assert(res.Writes[1].CommitTs, Equals, commitTs2)
+	c.Assert(bytes.Compare(res.Writes[1].ShortValue, newVal), Equals, 0)
+	c.Assert(res.Values[1].StartTs, Equals, startTs2)
+	c.Assert(bytes.Compare(res.Values[1].Value, newVal), Equals, 0)
+
+	c.Assert(res.Writes[0].StartTs, Equals, startTs3)
+	c.Assert(res.Writes[0].CommitTs, Equals, commitTs3)
+	c.Assert(bytes.Compare(res.Writes[0].ShortValue, emptyVal), Equals, 0)
+	c.Assert(res.Values[0].StartTs, Equals, startTs3)
+	c.Assert(bytes.Compare(res.Values[0].Value, emptyVal), Equals, 0)
+}

--- a/tikv/mvcc_test.go
+++ b/tikv/mvcc_test.go
@@ -509,7 +509,6 @@ func (s *testMvccSuite) TestMvccGetByKey(c *C) {
 	res, err = store.MvccStore.MvccGetByKey(reqCtx, pk)
 	c.Assert(err, IsNil)
 	c.Assert(len(res.Writes), Equals, 2)
-	c.Assert(len(res.Values), Equals, 2)
 
 	// prewrite and then rollback
 	// Add a Rollback whose start ts is 5.
@@ -530,24 +529,17 @@ func (s *testMvccSuite) TestMvccGetByKey(c *C) {
 	res, err = store.MvccStore.MvccGetByKey(reqCtx, pk)
 	c.Assert(err, IsNil)
 	c.Assert(len(res.Writes), Equals, 4)
-	c.Assert(len(res.Values), Equals, 4)
 	c.Assert(res.Writes[2].StartTs, Equals, startTs1)
 	c.Assert(res.Writes[2].CommitTs, Equals, commitTs1)
 	c.Assert(bytes.Compare(res.Writes[2].ShortValue, pkVal), Equals, 0)
-	c.Assert(res.Values[2].StartTs, Equals, startTs1)
-	c.Assert(bytes.Compare(res.Values[2].Value, pkVal), Equals, 0)
 
 	c.Assert(res.Writes[1].StartTs, Equals, startTs2)
 	c.Assert(res.Writes[1].CommitTs, Equals, commitTs2)
 	c.Assert(bytes.Compare(res.Writes[1].ShortValue, newVal), Equals, 0)
-	c.Assert(res.Values[1].StartTs, Equals, startTs2)
-	c.Assert(bytes.Compare(res.Values[1].Value, newVal), Equals, 0)
 
 	c.Assert(res.Writes[0].StartTs, Equals, startTs4)
 	c.Assert(res.Writes[0].CommitTs, Equals, commitTs4)
 	c.Assert(bytes.Compare(res.Writes[0].ShortValue, emptyVal), Equals, 0)
-	c.Assert(res.Values[0].StartTs, Equals, startTs4)
-	c.Assert(bytes.Compare(res.Values[0].Value, emptyVal), Equals, 0)
 
 	c.Assert(res.Writes[3].StartTs, Equals, startTs3)
 	c.Assert(res.Writes[3].CommitTs, Equals, startTs3)

--- a/tikv/server.go
+++ b/tikv/server.go
@@ -559,9 +559,22 @@ func (svr *Server) ReadIndex(context.Context, *kvrpcpb.ReadIndexRequest) (*kvrpc
 }
 
 // transaction debugger commands.
-func (svr *Server) MvccGetByKey(context.Context, *kvrpcpb.MvccGetByKeyRequest) (*kvrpcpb.MvccGetByKeyResponse, error) {
-	// TODO
-	return nil, nil
+func (svr *Server) MvccGetByKey(ctx context.Context, req *kvrpcpb.MvccGetByKeyRequest) (*kvrpcpb.MvccGetByKeyResponse, error) {
+	reqCtx, err := newRequestCtx(svr, req.Context, "MvccGetByKey")
+	if err != nil {
+		return &kvrpcpb.MvccGetByKeyResponse{Error: err.Error()}, nil
+	}
+	defer reqCtx.finish()
+	if reqCtx.regErr != nil {
+		return &kvrpcpb.MvccGetByKeyResponse{RegionError: reqCtx.regErr}, nil
+	}
+	resp := new(kvrpcpb.MvccGetByKeyResponse)
+	mvccInfo, err := svr.mvccStore.MvccGetByKey(reqCtx, req.GetKey())
+	if err != nil {
+		resp.Error = err.Error()
+	}
+	resp.Info = mvccInfo
+	return resp, nil
 }
 
 func (svr *Server) MvccGetByStartTs(context.Context, *kvrpcpb.MvccGetByStartTsRequest) (*kvrpcpb.MvccGetByStartTsResponse, error) {

--- a/tikv/server.go
+++ b/tikv/server.go
@@ -134,6 +134,8 @@ func (svr *Server) KvGet(ctx context.Context, req *kvrpcpb.GetRequest) (*kvrpcpb
 	}
 	if rowcodec.IsRowKey(req.Key) {
 		val, err = rowcodec.RowToOldRow(val, nil)
+	} else {
+		val = safeCopy(val)
 	}
 	return &kvrpcpb.GetResponse{
 		Value: val,


### PR DESCRIPTION
Support `MvccGetByKey`  command, add this rpc handler

```
create table t1(c1 int primary key, c2 int);
insert into t1 values(1,1);
update t1 set c2 = c2 + 1 where c1 = 1;
update t1 set c2 = c2 + 50 where c1 = 1;

curl http://127.0.0.1:10080/mvcc/key/test/t1/1
{
 "key": "74800000000000002B5F728000000000000001",
 "region_id": 8,
 "value": {
  "info": {
   "writes": [
    {
     "start_ts": 412951232233078785,
     "commit_ts": 412951232233078786,
     "short_value": "CAQIaA=="
    },
    {
     "start_ts": 412951231617302529,
     "commit_ts": 412951231630147585,
     "short_value": "CAQIBA=="
    },
    {
     "start_ts": 412951231053692929,
     "commit_ts": 412951231053692930,
     "short_value": "CAQIAg=="
    }
   ],
   "values": [
    {
     "start_ts": 412951232233078785,
     "value": "CAQIaA=="
    },
    {
     "start_ts": 412951231617302529,
     "value": "CAQIBA=="
    },
    {
     "start_ts": 412951231053692929,
     "value": "CAQIAg=="
    }
   ]
  }
 }
}
```