### PR TITLE
[storage] Support get mvcc by ts

### DIFF
--- a/tikv/dbreader/db_reader.go
+++ b/tikv/dbreader/db_reader.go
@@ -287,7 +287,7 @@ func (r *DBReader) GetKeyByStartTs(startKey, endKey []byte, startTs uint64) ([]b
 	for iter.Seek(startKey); iter.Valid(); iter.Next() {
 		curItem := iter.Item()
 		curKey := curItem.Key()
-		if bytes.Compare(curKey, endKey) > 0 {
+		if bytes.Compare(curKey, endKey) >= 0 {
 			break
 		}
 		meta := mvcc.DBUserMeta(curItem.UserMeta())
@@ -303,7 +303,7 @@ func (r *DBReader) GetKeyByStartTs(startKey, endKey []byte, startTs uint64) ([]b
 	for oldIter.Seek(oldStartKey); oldIter.Valid(); oldIter.Next() {
 		curItem := oldIter.Item()
 		oldKey := curItem.Key()
-		if bytes.Compare(oldKey, oldEndKey) > 0 {
+		if bytes.Compare(oldKey, oldEndKey) >= 0 {
 			break
 		}
 		oldMeta := mvcc.OldUserMeta(curItem.UserMeta())

--- a/tikv/dbreader/db_reader.go
+++ b/tikv/dbreader/db_reader.go
@@ -60,15 +60,6 @@ func (r *DBReader) GetMvccInfoByKey(key []byte, isRowKey bool, mvccInfo *kvrpcpb
 	return nil
 }
 
-// GetMvccInfoByOldKey fills MvccInfo reading old keys from db
-func (r *DBReader) GetMvccInfoByOldKey(oldKey []byte, isRowKey bool, mvccInfo *kvrpcpb.MvccInfo) error {
-	err := r.getOldKeysWithMeta(oldKey, isRowKey, mvccInfo)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 // getKeyWithMeta will try to get current key without looking for historical version
 func (r *DBReader) getKeyWithMeta(key []byte, isRowKey bool, startTs uint64, mvccInfo *kvrpcpb.MvccInfo) error {
 	item, err := r.txn.Get(key)

--- a/tikv/dbreader/db_reader.go
+++ b/tikv/dbreader/db_reader.go
@@ -51,10 +51,20 @@ func (r *DBReader) GetMvccInfoByKey(key []byte, isRowKey bool, mvccInfo *kvrpcpb
 		return err
 	}
 	if len(mvccInfo.Writes) > 0 {
-		err = r.getOldKeysWithMeta(key, mvccInfo.Writes[0].CommitTs, isRowKey, mvccInfo)
+		oldKey := mvcc.EncodeOldKey(key, mvccInfo.Writes[0].CommitTs)
+		err = r.getOldKeysWithMeta(oldKey, isRowKey, mvccInfo)
 		if err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// GetMvccInfoByOldKey fills MvccInfo reading old keys from db
+func (r *DBReader) GetMvccInfoByOldKey(oldKey []byte, isRowKey bool, mvccInfo *kvrpcpb.MvccInfo) error {
+	err := r.getOldKeysWithMeta(oldKey, isRowKey, mvccInfo)
+	if err != nil {
+		return err
 	}
 	return nil
 }
@@ -98,11 +108,11 @@ func (r *DBReader) getKeyWithMeta(key []byte, isRowKey bool, startTs uint64, mvc
 }
 
 // getOldKeysWithMeta will try to fill mvccInfo with all the historical committed records
-func (r *DBReader) getOldKeysWithMeta(key []byte, startTs uint64, isRowKey bool, mvccInfo *kvrpcpb.MvccInfo) error {
-	oldKey := mvcc.EncodeOldKey(key, startTs)
-	iter := r.GetIter()
-	for iter.Seek(oldKey); iter.ValidForPrefix(oldKey[:len(oldKey)-8]); iter.Next() {
-		item := iter.Item()
+// the oldKey should be in old-key encoded format
+func (r *DBReader) getOldKeysWithMeta(oldKey []byte, isRowKey bool, mvccInfo *kvrpcpb.MvccInfo) error {
+	oldIter := r.GetOldIter()
+	for oldIter.Seek(oldKey); oldIter.ValidForPrefix(oldKey[:len(oldKey)-8]); oldIter.Next() {
+		item := oldIter.Item()
 		oldUsrMeta := mvcc.OldUserMeta(item.UserMeta())
 		commitTs, err := mvcc.DecodeOldKeyCommitTs(item.Key())
 		if err != nil {
@@ -171,9 +181,13 @@ func (r *DBReader) getReverseIter() *badger.Iterator {
 func (r *DBReader) GetOldIter() *badger.Iterator {
 	if r.oldIter == nil {
 		oldStartKey := append([]byte{}, r.startKey...)
-		oldStartKey[0]++
+		if len(oldStartKey) > 0 {
+			oldStartKey[0]++
+		}
 		oldEndKey := append([]byte{}, r.endKey...)
-		oldEndKey[0]++
+		if len(oldEndKey) > 0 {
+			oldEndKey[0]++
+		}
 		r.oldIter = NewIterator(r.txn, false, oldStartKey, oldEndKey)
 	}
 	return r.oldIter

--- a/tikv/mvcc.go
+++ b/tikv/mvcc.go
@@ -1048,11 +1048,3 @@ func (f *GCCompactionFilter) Guards() []badger.Guard {
 		baseGuard, raftGuard, metaGuard, metaOldGuard, tableIndexGuard, tableIndexOldGuard,
 	}
 }
-
-// IsRecordKey returns current key type, true if it's record type
-func IsRecordKey(key []byte) bool {
-	if len(key) > 1 && key[0] == tablePrefix {
-		return true
-	}
-	return false
-}

--- a/tikv/mvcc/mvcc.go
+++ b/tikv/mvcc/mvcc.go
@@ -110,6 +110,21 @@ func EncodeOldKey(key []byte, ts uint64) []byte {
 	return ret
 }
 
+// DecodeOldKey returns the rawkey and commitTs from oldKey
+func DecodeOldKey(oldKey []byte) ([]byte, uint64, error) {
+	if len(oldKey) < 8 {
+		return nil, 0, errors.Errorf("invalid input key=%v length=%d less than 8 bytes", oldKey, len(oldKey))
+	}
+	buf := append([]byte{}, oldKey...)
+	buf[0]--
+	rawKey := buf[:len(buf)-8]
+	_, res, err := codec.DecodeUintDesc(buf[len(buf)-8:])
+	if err != nil {
+		return nil, 0, err
+	}
+	return rawKey, res, nil
+}
+
 // DecodeOldKeyCommitTs decodes commitTs from encoded old key
 func DecodeOldKeyCommitTs(key []byte) (uint64, error) {
 	if len(key) < 8 {

--- a/tikv/mvcc_test.go
+++ b/tikv/mvcc_test.go
@@ -286,7 +286,7 @@ func (s *testMvccSuite) TestCheckTxnStatus(c *C) {
 
 	var resTTL, resCommitTs uint64
 	var action kvrpcpb.Action
-	pk := []byte("pk")
+	pk := []byte("tpk")
 	startTs := uint64(1)
 	callerStartTs := uint64(3)
 	currentTs := uint64(5)
@@ -381,9 +381,20 @@ func (s *testMvccSuite) TestCheckTxnStatus(c *C) {
 	c.Assert(action, Equals, kvrpcpb.Action_NoAction)
 }
 
-func (s *testMvccSuite) TestMvccGetByKey(c *C) {
+func (s *testMvccSuite) TestDecodeOldKey(c *C) {
+	rawKey := []byte("trawKey")
+	oldCommitTs := uint64(1)
+	oldKey := mvcc.EncodeOldKey(rawKey, oldCommitTs)
+
+	resKey, resTs, err := mvcc.DecodeOldKey(oldKey)
+	c.Assert(err, IsNil)
+	c.Assert(bytes.Compare(resKey, rawKey), Equals, 0)
+	c.Assert(resTs, Equals, oldCommitTs)
+}
+
+func (s *testMvccSuite) TestMvccGet(c *C) {
 	var err error
-	store, err := NewTestStore("TestMvccGetByKey", "TestMvccGetByKey")
+	store, err := NewTestStore("TestMvccGetBy", "TestMvccGetBy")
 	c.Assert(err, IsNil)
 	defer CleanTestStore(store)
 
@@ -442,6 +453,49 @@ func (s *testMvccSuite) TestMvccGetByKey(c *C) {
 	c.Assert(res.Writes[3].StartTs, Equals, startTs3)
 	c.Assert(res.Writes[3].CommitTs, Equals, startTs3)
 	c.Assert(bytes.Compare(res.Writes[3].ShortValue, []byte{0}), Equals, 0)
+
+	// read using MvccGetByStartTs using key current ts
+	res2, resKey, err := store.MvccStore.MvccGetByStartTs(store.newReqCtx(), startTs4)
+	c.Assert(err, IsNil)
+	c.Assert(res2, NotNil)
+	c.Assert(bytes.Compare(resKey, pk), Equals, 0)
+	c.Assert(len(res2.Writes), Equals, 4)
+	c.Assert(res2.Writes[2].StartTs, Equals, startTs1)
+	c.Assert(res2.Writes[2].CommitTs, Equals, commitTs1)
+	c.Assert(bytes.Compare(res2.Writes[2].ShortValue, pkVal), Equals, 0)
+
+	c.Assert(res2.Writes[1].StartTs, Equals, startTs2)
+	c.Assert(res2.Writes[1].CommitTs, Equals, commitTs2)
+	c.Assert(bytes.Compare(res2.Writes[1].ShortValue, newVal), Equals, 0)
+
+	c.Assert(res2.Writes[0].StartTs, Equals, startTs4)
+	c.Assert(res2.Writes[0].CommitTs, Equals, commitTs4)
+	c.Assert(bytes.Compare(res2.Writes[0].ShortValue, emptyVal), Equals, 0)
+
+	c.Assert(res2.Writes[3].StartTs, Equals, startTs3)
+	c.Assert(res2.Writes[3].CommitTs, Equals, startTs3)
+	c.Assert(bytes.Compare(res2.Writes[3].ShortValue, []byte{0}), Equals, 0)
+
+	// read using MvccGetByStartTs using non exists startTs
+	startTsNonExists := uint64(1000)
+	res3, resKey, err := store.MvccStore.MvccGetByStartTs(store.newReqCtx(), startTsNonExists)
+	c.Assert(err, IsNil)
+	c.Assert(resKey, IsNil)
+	c.Assert(res3, IsNil)
+
+	// read using old startTs
+	res4, resKey, err := store.MvccStore.MvccGetByStartTs(store.newReqCtx(), startTs2)
+	c.Assert(err, IsNil)
+	c.Assert(res4, NotNil)
+	c.Assert(bytes.Compare(resKey, pk), Equals, 0)
+	c.Assert(len(res4.Writes), Equals, 2)
+	c.Assert(res4.Writes[1].StartTs, Equals, startTs1)
+	c.Assert(res4.Writes[1].CommitTs, Equals, commitTs1)
+	c.Assert(bytes.Compare(res4.Writes[1].ShortValue, pkVal), Equals, 0)
+
+	c.Assert(res4.Writes[0].StartTs, Equals, startTs2)
+	c.Assert(res4.Writes[0].CommitTs, Equals, commitTs2)
+	c.Assert(bytes.Compare(res4.Writes[0].ShortValue, newVal), Equals, 0)
 }
 
 func (s *testMvccSuite) TestPrimaryKeyOpLock(c *C) {

--- a/tikv/mvcc_test.go
+++ b/tikv/mvcc_test.go
@@ -488,33 +488,23 @@ func (s *testMvccSuite) TestMvccGet(c *C) {
 	c.Assert(res3, IsNil)
 
 	// read using old startTs
-	st := []byte("t1_r0") // using t1_r1 as startKey, seek to start will fail?
-	ed := []byte("t1_r2")
-	res4, resKey, err := store.MvccStore.MvccGetByStartTs(store.newReqCtxWithKeys(st, ed), startTs2)
+	res4, resKey, err := store.MvccStore.MvccGetByStartTs(store.newReqCtx(), startTs2)
 	c.Assert(err, IsNil)
 	c.Assert(res4, NotNil)
 	c.Assert(bytes.Compare(resKey, pk), Equals, 0)
-	c.Assert(len(res4.Writes), Equals, 2)
-	c.Assert(res4.Writes[1].StartTs, Equals, startTs1)
-	c.Assert(res4.Writes[1].CommitTs, Equals, commitTs1)
-	c.Assert(bytes.Compare(res4.Writes[1].ShortValue, pkVal), Equals, 0)
+	c.Assert(len(res4.Writes), Equals, 4)
+	c.Assert(res4.Writes[3].StartTs, Equals, startTs3)
+	c.Assert(res4.Writes[3].CommitTs, Equals, startTs3)
+	c.Assert(bytes.Compare(res4.Writes[3].ShortValue, []byte{0}), Equals, 0)
 
-	c.Assert(res4.Writes[0].StartTs, Equals, startTs2)
-	c.Assert(res4.Writes[0].CommitTs, Equals, commitTs2)
-	c.Assert(bytes.Compare(res4.Writes[0].ShortValue, newVal), Equals, 0)
-
-	res4, resKey, err = store.MvccStore.MvccGetByStartTs(store.newReqCtx(), startTs2)
+	res4, resKey, err = store.MvccStore.MvccGetByStartTs(store.newReqCtxWithKeys([]byte("t1_r1"), []byte("t1_r2")), startTs2)
 	c.Assert(err, IsNil)
 	c.Assert(res4, NotNil)
 	c.Assert(bytes.Compare(resKey, pk), Equals, 0)
-	c.Assert(len(res4.Writes), Equals, 2)
-	c.Assert(res4.Writes[1].StartTs, Equals, startTs1)
-	c.Assert(res4.Writes[1].CommitTs, Equals, commitTs1)
-	c.Assert(bytes.Compare(res4.Writes[1].ShortValue, pkVal), Equals, 0)
-
-	c.Assert(res4.Writes[0].StartTs, Equals, startTs2)
-	c.Assert(res4.Writes[0].CommitTs, Equals, commitTs2)
-	c.Assert(bytes.Compare(res4.Writes[0].ShortValue, newVal), Equals, 0)
+	c.Assert(len(res4.Writes), Equals, 4)
+	c.Assert(res4.Writes[3].StartTs, Equals, startTs3)
+	c.Assert(res4.Writes[3].CommitTs, Equals, startTs3)
+	c.Assert(bytes.Compare(res4.Writes[3].ShortValue, []byte{0}), Equals, 0)
 }
 
 func (s *testMvccSuite) TestPrimaryKeyOpLock(c *C) {

--- a/tikv/server.go
+++ b/tikv/server.go
@@ -579,9 +579,23 @@ func (svr *Server) MvccGetByKey(ctx context.Context, req *kvrpcpb.MvccGetByKeyRe
 	return resp, nil
 }
 
-func (svr *Server) MvccGetByStartTs(context.Context, *kvrpcpb.MvccGetByStartTsRequest) (*kvrpcpb.MvccGetByStartTsResponse, error) {
-	// TODO
-	return nil, nil
+func (svr *Server) MvccGetByStartTs(ctx context.Context, req *kvrpcpb.MvccGetByStartTsRequest) (*kvrpcpb.MvccGetByStartTsResponse, error) {
+	reqCtx, err := newRequestCtx(svr, req.Context, "MvccGetByStartTs")
+	if err != nil {
+		return &kvrpcpb.MvccGetByStartTsResponse{Error: err.Error()}, nil
+	}
+	defer reqCtx.finish()
+	if reqCtx.regErr != nil {
+		return &kvrpcpb.MvccGetByStartTsResponse{RegionError: reqCtx.regErr}, nil
+	}
+	resp := new(kvrpcpb.MvccGetByStartTsResponse)
+	mvccInfo, key, err := svr.mvccStore.MvccGetByStartTs(reqCtx, req.StartTs)
+	if err != nil {
+		resp.Error = err.Error()
+	}
+	resp.Info = mvccInfo
+	resp.Key = key
+	return resp, nil
 }
 
 func (svr *Server) UnsafeDestroyRange(context.Context, *kvrpcpb.UnsafeDestroyRangeRequest) (*kvrpcpb.UnsafeDestroyRangeResponse, error) {


### PR DESCRIPTION
Support mvcc get ts read for debugging usage

```
curl http://127.0.0.1:10080/mvcc/txn/405179368526053377/test/t1
```
Returns the transaction commits/rollbacks up to the input startTs