### PR TITLE
make kv cleanup compatible and do check the lock ttl

### DIFF
--- a/tikv/errors.go
+++ b/tikv/errors.go
@@ -39,6 +39,14 @@ func (e ErrAlreadyCommitted) Error() string {
 	return "txn already committed"
 }
 
+type ErrCommitPessimisticLock struct {
+	key []byte
+}
+
+func (e ErrCommitPessimisticLock) Error() string {
+	return fmt.Sprintf("txn commit pessimistic lock directly on key=%v", e.key)
+}
+
 type ErrKeyAlreadyExists struct {
 	Key []byte
 }


### PR DESCRIPTION
1. Make cleanup compatible, do check the lock TTL
2. Report error if committing pessimistic locks
3. Report error if pessimistic lock on rollbacked entry
4. Port txn tests(Pessimistic related)(
tikv package coverage 22.1% ->  28.3%
mvcc.go  52% -> 72%, currently most mvcc txn related interfaces are recorded)

Incompatibilities with tikv
1. Unistore will not collapse rollback record
2. Unistore pessimistic rollback will not be recorded, so the earlier raised pessimistic lock will succeed if arriving later than rollback operation