### PR TITLE
fix closure executor bug

### DIFF
--- a/tikv/closure_exec.go
+++ b/tikv/closure_exec.go
@@ -55,6 +55,7 @@ func (svr *Server) buildClosureExecutor(dagCtx *dagContext, dagReq *tipb.DAGRequ
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+		ce.processor = &selectionProcessor{closureExecutor: ce}
 	}
 	lastExecutor := executors[len(executors)-1]
 	switch lastExecutor.Tp {


### PR DESCRIPTION
When dag executor is TableScan->Selection->Limit, the selection is not evaluated.