### PR TITLE
add logic for pessimistic lock rollback restore

### DIFF
--- a/tikv/raftstore/restore_test.go
+++ b/tikv/raftstore/restore_test.go
@@ -1,0 +1,86 @@
+package raftstore
+
+import (
+	"testing"
+
+	"github.com/ngaut/unistore/lockstore"
+	"github.com/ngaut/unistore/tikv/mvcc"
+	"github.com/pingcap/kvproto/pkg/eraftpb"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	rcpb "github.com/pingcap/kvproto/pkg/raft_cmdpb"
+	"github.com/stretchr/testify/require"
+)
+
+func genEntry(wb *raftWriteBatch, t *testing.T) *eraftpb.Entry {
+	header := &rcpb.RaftRequestHeader{
+		RegionId: 1,
+		Term:     1,
+	}
+	request := &rcpb.RaftCmdRequest{
+		Header:   header,
+		Requests: wb.requests,
+	}
+	data, err := request.Marshal()
+	require.Nil(t, err)
+	entry := &eraftpb.Entry{Data: data, Context: nil}
+	return entry
+}
+
+func TestRestore(t *testing.T) {
+	engines := newTestEngines(t)
+	defer cleanUpTestEngineData(engines)
+	wb := &raftWriteBatch{
+		startTS:  1,
+		commitTS: 0,
+	}
+	k1 := []byte("tk")
+	v1 := []byte("v")
+
+	lockStore := lockstore.NewMemStore(1000)
+	rollbackStore := lockstore.NewMemStore(1000)
+	// Restore prewrite
+	expectLock := mvcc.MvccLock{
+		MvccLockHdr: mvcc.MvccLockHdr{
+			StartTS:    1,
+			TTL:        10,
+			Op:         uint8(kvrpcpb.Op_Put),
+			PrimaryLen: uint16(len(k1)),
+		},
+		Primary: k1,
+		Value:   v1,
+	}
+	wb.Prewrite(k1, &expectLock, false)
+	txn := engines.kv.DB.NewTransaction(true)
+	err := restoreAppliedEntry(genEntry(wb, t), txn, lockStore, rollbackStore)
+	require.Nil(t, err)
+
+	// Restore commit
+	wbCommit := &raftWriteBatch{
+		startTS:  1,
+		commitTS: 2,
+	}
+	wbCommit.Commit(k1, &expectLock)
+	txn = engines.kv.DB.NewTransaction(true)
+	err = restoreAppliedEntry(genEntry(wbCommit, t), txn, lockStore, rollbackStore)
+	require.Nil(t, err)
+
+	// Restore common rollback
+	wbRollback := &raftWriteBatch{
+		startTS:  3,
+		commitTS: 0,
+	}
+	wbRollback.Rollback(k1, true)
+	txn = engines.kv.DB.NewTransaction(true)
+	err = restoreAppliedEntry(genEntry(wbRollback, t), txn, lockStore, rollbackStore)
+	require.Nil(t, err)
+
+	// Restore pessimistic rollback
+	wbPessimisticRollback := &raftWriteBatch{
+		startTS:  5,
+		commitTS: 6,
+	}
+	wbPessimisticRollback.PessimisticRollback(k1)
+	txn = engines.kv.DB.NewTransaction(true)
+	err = restoreAppliedEntry(genEntry(wbPessimisticRollback, t), txn, lockStore, rollbackStore)
+	require.Nil(t, err)
+}


### PR DESCRIPTION
The pessimistic lock rollback should use the key from `delLock` field, or the restart of unistore may panic
like
```
goroutine 1 [running]:
github.com/ngaut/unistore/tikv/raftstore.restoreRollback(0x0, 0x0, 0xc04d54dbd0, 0xc0001516e0)
	/home/rwork/go/src/unistore/tikv/raftstore/restore.go:105 +0x37
github.com/ngaut/unistore/tikv/raftstore.restoreAppliedEntry(0xc0001376e0, 0xc0004302d0, 0xc000151680, 0xc0001516e0, 0x0, 0x0)
	/home/rwork/go/src/unistore/tikv/raftstore/restore.go:81 +0x18e
github.com/ngaut/unistore/tikv/raftstore.RestoreLockStore.func1(0xc0001961b0, 0x1b, 0x26, 0xc04d4cc000, 0x95, 0x2788a, 0x0, 0x0, 0x0, 0x40, ...)
	/home/rwork/go/src/unistore/tikv/raftstore/restore.go:43 +0x180
github.com/coocood/badger.(*DB).IterateVLog.func1(0xc0001961b0, 0x1b, 0x26, 0xc04d4cc000, 0x95, 0x2788a, 0x0, 0x0, 0x0, 0x40, ...)
	/home/rwork/go/pkg/mod/github.com/coocood/badger@v1.5.1-0.20191224120441-29dd586ca27d/db.go:1051 +0x6e
github.com/coocood/badger.(*valueLog).iterate(0xc0001d0620, 0xc00031f280, 0xc000000000, 0xc0001379e8, 0x0, 0x13b4040, 0xc0004302d0)
	/home/rwork/go/pkg/mod/github.com/coocood/badger@v1.5.1-0.20191224120441-29dd586ca27d/value.go:239 +0x450
github.com/coocood/badger.(*DB).IterateVLog(0xc0001d0480, 0x0, 0xc000137b50, 0x22aeea8, 0xc000137a70)
	/home/rwork/go/pkg/mod/github.com/coocood/badger@v1.5.1-0.20191224120441-29dd586ca27d/db.go:1049 +0xfb
github.com/ngaut/unistore/tikv/raftstore.RestoreLockStore(0x0, 0xc00031e1e0, 0xc0001d0480, 0x0, 0x0)
	/home/rwork/go/src/unistore/tikv/raftstore/restore.go:22 +0x189
```

Add related processing logic and coverage test case