### PR TITLE
set default split keys

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -103,6 +103,10 @@ var DefaultConf = Config{
 		Compression:      make([]string, 7),
 		BlockCacheSize:   1 << 30,
 	},
+	Coprocessor: Coprocessor{
+		RegionMaxKeys:   1440000,
+		RegionSplitKeys: 960000,
+	},
 }
 
 // parseDuration parses duration argument string.


### PR DESCRIPTION
If the default value of split keys is not set, batch split would fail.