### PR TITLE
lockstore supports Put operation

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,7 @@ github.com/cznic/sortutil v0.0.0-20181122101858-f5f958428db8/go.mod h1:q2w6Bg5je
 github.com/cznic/strutil v0.0.0-20171016134553-529a34b1c186/go.mod h1:AHHPPPXTw0h6pVabbcbyGRK1DckRn7r/STdZEeIDzZc=
 github.com/cznic/y v0.0.0-20170802143616-045f81c6662a/go.mod h1:1rk5VM7oSnA4vjp+hrLQ3HWHa+Y4yPCa3/CsJrcNnvs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgraph-io/ristretto v0.0.0-20191010170704-2ba187ef9534/go.mod h1:edzKIzGvqUCMzhTVWbiTSe75zD9Xxq0GtSBtFmaUTZs=
 github.com/dgraph-io/ristretto v0.0.1 h1:cJwdnj42uV8Jg4+KLrYovLiCgIfz9wtWm6E6KA+1tLs=
@@ -173,6 +174,7 @@ github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8/go.mod h1:B1+S9LNcuMyLH/4HMTViQOJevkGiik3wW2AN9zb2fNQ=
 github.com/pingcap/check v0.0.0-20191107115940-caf2b9e6ccf4/go.mod h1:PYMCGwN0JHjoqGr3HrZoD+b8Tgx8bKnArhSq8YVzUMc=
+github.com/pingcap/check v0.0.0-20191216031241-8a5a85928f12 h1:rfD9v3+ppLPzoQBgZev0qYCpegrwyFx/BUpkApEiKdY=
 github.com/pingcap/check v0.0.0-20191216031241-8a5a85928f12/go.mod h1:PYMCGwN0JHjoqGr3HrZoD+b8Tgx8bKnArhSq8YVzUMc=
 github.com/pingcap/errcode v0.0.0-20180921232412-a1a7271709d9/go.mod h1:4b2X8xSqxIroj/IZ9MX/VGZhAwc11wB9wRIzHvz6SeM=
 github.com/pingcap/errors v0.11.0/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
@@ -205,6 +207,7 @@ github.com/pingcap/tipb v0.0.0-20191209145133-44f75c9bef33/go.mod h1:RtkHW8WbcNx
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -252,6 +255,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/struCoder/pidusage v0.1.2/go.mod h1:pWBlW3YuSwRl6h7R5KbvA4N8oOqe9LjaKW5CwT1SPjI=
 github.com/syndtr/goleveldb v0.0.0-20180815032940-ae2bd5eed72d/go.mod h1:Z4AUp2Km+PwemOoO/VB5AOx9XSsIItzFjoJlOSiYmn0=
@@ -384,6 +388,7 @@ gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXL
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/lockstore/load_dump.go
+++ b/lockstore/load_dump.go
@@ -38,7 +38,7 @@ func (ls *MemStore) LoadFromFile(fileName string) (meta []byte, err error) {
 			return nil, errors.Trace(err)
 		}
 		cnt++
-		ls.Insert(keyBuf, valBuf)
+		ls.Put(keyBuf, valBuf)
 	}
 	log.Infof("loaded lockstore with %d entries", cnt)
 	return meta, nil

--- a/tikv/cop_handler_test.go
+++ b/tikv/cop_handler_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
+	"github.com/pingcap/tidb/util/rowcodec"
 	"github.com/pingcap/tipb/go-tipb"
 	"github.com/stretchr/testify/require"
 )
@@ -102,7 +103,7 @@ func prepareTestTableData(t *testing.T, keyNumber int, tableId int64) *data {
 	for i := 0; i < keyNumber; i++ {
 		datum := types.MakeDatums(i, "abc", 10.0)
 		rows[int64(i)] = datum
-		rowEncodedData, err := tablecodec.EncodeRow(stmtCtx, datum, colIds, nil, nil)
+		rowEncodedData, err := tablecodec.EncodeRow(stmtCtx, datum, colIds, nil, nil, &rowcodec.Encoder{})
 		require.Nil(t, err)
 		rowKeyEncodedData := tablecodec.EncodeRowKeyWithHandle(tableId, int64(i))
 		encodedTestKVDatas[i] = &encodedTestKVData{encodedRowKey: rowKeyEncodedData, encodedRowValue: rowEncodedData}

--- a/tikv/raftstore/fsm_peer.go
+++ b/tikv/raftstore/fsm_peer.go
@@ -832,7 +832,7 @@ func (d *peerMsgHandler) onReadySplitRegion(derived *metapb.Region, regions []*m
 	newPeers := make([]*PeerEventContext, 0, len(regions))
 	for _, newRegion := range regions {
 		newRegionID := newRegion.Id
-		notExist := meta.regionRanges.Insert(newRegion.EndKey, regionIDToBytes(newRegionID))
+		notExist := meta.regionRanges.Put(newRegion.EndKey, regionIDToBytes(newRegionID))
 		y.Assert(notExist)
 		if newRegionID == regionID {
 			newPeers = append(newPeers, d.peer.getEventContext())
@@ -952,7 +952,7 @@ func (d *peerMsgHandler) onReadyApplySnapshot(applyResult *ApplySnapResult) {
 		log.Infof("%s region changed from %s -> %s after applying snapshot", d.tag(), prevRegion, region)
 		meta.regionRanges.Delete(prevRegion.EndKey)
 	}
-	if !meta.regionRanges.Insert(region.EndKey, regionIDToBytes(region.Id)) {
+	if !meta.regionRanges.Put(region.EndKey, regionIDToBytes(region.Id)) {
 		oldRegionID := regionIDFromBytes(meta.regionRanges.Get(region.EndKey, nil))
 		panic(fmt.Sprintf("%s unexpected old region %d", d.tag(), oldRegionID))
 	}

--- a/tikv/raftstore/fsm_store.go
+++ b/tikv/raftstore/fsm_store.go
@@ -272,7 +272,7 @@ func (bs *raftBatchSystem) loadPeers() ([]*peerFsm, error) {
 				mergingCount++
 				peer.setPendingMergeState(localState.MergeState)
 			}
-			meta.regionRanges.Insert(region.EndKey, regionIDToBytes(regionID))
+			meta.regionRanges.Put(region.EndKey, regionIDToBytes(regionID))
 			meta.regions[regionID] = region
 			// No need to check duplicated here, because we use region id as the key
 			// in DB.
@@ -298,7 +298,7 @@ func (bs *raftBatchSystem) loadPeers() ([]*peerFsm, error) {
 			return nil, err
 		}
 		peer.scheduleApplyingSnapshot()
-		meta.regionRanges.Insert(region.EndKey, regionIDToBytes(region.Id))
+		meta.regionRanges.Put(region.EndKey, regionIDToBytes(region.Id))
 		meta.regions[region.Id] = region
 		regionPeers = append(regionPeers, peer)
 	}

--- a/tikv/raftstore/restore.go
+++ b/tikv/raftstore/restore.go
@@ -90,7 +90,7 @@ func restoreAppliedEntry(entry *eraftpb.Entry, txn *badger.Txn, lockStore, rollb
 
 func restorePrewrite(op prewriteOp, txn *badger.Txn, lockStore *lockstore.MemStore) {
 	key, value := convertPrewriteToLock(op, txn)
-	lockStore.Insert(key, value)
+	lockStore.Put(key, value)
 }
 
 func restoreCommit(op commitOp, lockStore *lockstore.MemStore) {
@@ -116,7 +116,7 @@ func restoreRollback(op rollbackOp, rollbackStore *lockstore.MemStore) {
 	if err != nil {
 		panic(err)
 	}
-	rollbackStore.Insert(append(rawKey, remain...), []byte{0})
+	rollbackStore.Put(append(rawKey, remain...), []byte{0})
 }
 
 func isRaftLogKey(key []byte) bool {

--- a/tikv/raftstore/snap.go
+++ b/tikv/raftstore/snap.go
@@ -760,9 +760,9 @@ func (s *Snap) Apply(opts ApplyOptions) (ApplyResult, error) {
 				UserMeta: item.userMeta,
 			})
 		case applySnapTypeLock:
-			opts.DBBundle.LockStore.Insert(item.key, item.val)
+			opts.DBBundle.LockStore.Put(item.key, item.val)
 		case applySnapTypeRollback:
-			opts.DBBundle.RollbackStore.Insert(item.key, item.val)
+			opts.DBBundle.RollbackStore.Put(item.key, item.val)
 		}
 	}
 

--- a/tikv/raftstore/snap_test.go
+++ b/tikv/raftstore/snap_test.go
@@ -165,7 +165,7 @@ func fillDBBundleData(t *testing.T, dbBundle *mvcc.DBBundle) {
 		OldVal:  make([]byte, 32),
 		OldMeta: mvcc.NewDBUserMeta(150, 200),
 	}
-	dbBundle.LockStore.Insert(snapTestKey, lockVal.MarshalBinary())
+	dbBundle.LockStore.Put(snapTestKey, lockVal.MarshalBinary())
 }
 
 func TestSnapGenMeta(t *testing.T) {

--- a/tikv/raftstore/worker.go
+++ b/tikv/raftstore/worker.go
@@ -504,7 +504,7 @@ func (pendDelRanges *pendingDeleteRanges) insert(regionId uint64, startKey, endK
 		panic(fmt.Sprintf("[region %d] register deleting data in [%v, %v) failed due to overlap", regionId, startKey, endKey))
 	}
 	peerInfo := newStalePeerInfo(regionId, endKey, timeout)
-	pendDelRanges.ranges.Insert(startKey, peerInfo.data)
+	pendDelRanges.ranges.Put(startKey, peerInfo.data)
 }
 
 // remove removes and returns the peer info with the `start_key`.

--- a/tikv/write.go
+++ b/tikv/write.go
@@ -156,7 +156,7 @@ func (w writeLockWorker) run() {
 			for _, entry := range batch.entries {
 				switch entry.UserMeta[0] {
 				case mvcc.LockUserMetaRollbackByte:
-					rollbackStore.Insert(entry.Key, []byte{0})
+					rollbackStore.Put(entry.Key, []byte{0})
 				case mvcc.LockUserMetaDeleteByte:
 					delCnt++
 					if !ls.Delete(entry.Key) {
@@ -166,7 +166,7 @@ func (w writeLockWorker) run() {
 					rollbackStore.Delete(entry.Key)
 				default:
 					insertCnt++
-					if !ls.Insert(entry.Key, entry.Value) {
+					if !ls.Put(entry.Key, entry.Value) {
 						panic("failed to insert key")
 					}
 				}

--- a/unistore-server/main.go
+++ b/unistore-server/main.go
@@ -82,6 +82,7 @@ func main() {
 	conf := loadConfig()
 	loadCmdConf(conf)
 	runtime.GOMAXPROCS(conf.Server.MaxProcs)
+	runtime.SetMutexProfileFraction(10)
 	if conf.Server.LogfilePath != "" {
 		err := log.SetOutputByName(conf.Server.LogfilePath)
 		if err != nil {


### PR DESCRIPTION
So we don’t need to call Delete and Insert when update an entry.