### PR TITLE
support custom raft log to boost batch insert performance

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,7 @@ type RaftStore struct {
 	RaftBaseTickInterval     string `toml:"raft-base-tick-interval"`     // raft-base-tick-interval in milliseconds
 	RaftHeartbeatTicks       int    `toml:"raft-heartbeat-ticks"`        // raft-heartbeat-ticks times
 	RaftElectionTimeoutTicks int    `toml:"raft-election-timeout-ticks"` // raft-election-timeout-ticks times
+	CustomRaftLog            bool   `toml:"custom-raft-log"`
 }
 
 type Coprocessor struct {
@@ -88,6 +89,7 @@ var DefaultConf = Config{
 		RaftBaseTickInterval:     "1s",
 		RaftHeartbeatTicks:       2,
 		RaftElectionTimeoutTicks: 10,
+		CustomRaftLog:            true,
 	},
 	Engine: Engine{
 		DBPath:           "/tmp/badger",
@@ -97,7 +99,6 @@ var DefaultConf = Config{
 		NumL0Tables:      4,
 		NumL0TablesStall: 8,
 		VlogFileSize:     256 * MB,
-		SyncWrite:        true,
 		NumCompactors:    1,
 		SurfStartLevel:   8,
 		Compression:      make([]string, 7),

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,9 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DataDog/zstd v1.4.1 h1:3oxKN3wbHibqx897utPC2LTQU4J+IHWWJO+glkAkpFM=
+github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -12,9 +15,11 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/blacktear23/go-proxyprotocol v0.0.0-20180807104634-af7a81e8dd0d/go.mod h1:VKt7CNAQxpFpSDz3sXyj9hY/GbVsQCr0sB3w59nE7lU=
+github.com/brianvoe/gofakeit v3.18.0+incompatible/go.mod h1:kfwdRA90vvNhPutZWfH7WPaDzUjz+CZFqG+rPkOjGOc=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
+github.com/cespare/xxhash/v2 v2.1.0/go.mod h1:dgIUBU3pDso/gPgZ1osOZ0iQf77oPR28Tjxl5dIMyVM=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20171208011716-f6d7a1f6fbf3/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -48,6 +53,7 @@ github.com/cznic/y v0.0.0-20170802143616-045f81c6662a/go.mod h1:1rk5VM7oSnA4vjp+
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgraph-io/ristretto v0.0.0-20191010170704-2ba187ef9534/go.mod h1:edzKIzGvqUCMzhTVWbiTSe75zD9Xxq0GtSBtFmaUTZs=
 github.com/dgraph-io/ristretto v0.0.1 h1:cJwdnj42uV8Jg4+KLrYovLiCgIfz9wtWm6E6KA+1tLs=
 github.com/dgraph-io/ristretto v0.0.1/go.mod h1:T40EBc7CJke8TkpiYfGGKAeFjSaxuFXhuXRyumBd6RE=
@@ -243,6 +249,8 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
+github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
@@ -253,6 +261,7 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=

--- a/tikv/mvcc/db_writer.go
+++ b/tikv/mvcc/db_writer.go
@@ -23,7 +23,7 @@ type LatchHandle interface {
 }
 
 type WriteBatch interface {
-	Prewrite(key []byte, lock *MvccLock, isPessimisticLock bool)
+	Prewrite(key []byte, lock *MvccLock)
 	Commit(key []byte, lock *MvccLock)
 	Rollback(key []byte, deleleLock bool)
 	PessimisticLock(key []byte, lock *MvccLock)

--- a/tikv/raftstore/applier.go
+++ b/tikv/raftstore/applier.go
@@ -22,7 +22,6 @@ import (
 )
 
 const (
-	WriteBatchMaxKeys  = 128
 	DefaultApplyWBSize = 4 * 1024
 
 	WriteTypeFlagPut      = 'P'
@@ -445,12 +444,6 @@ func shouldWriteToEngine(rlog raftlog.RaftLog, wbKeys int) bool {
 			raft_cmdpb.AdminCmdType_RollbackMerge:
 			return true
 		}
-	}
-
-	// When write batch contains more than `recommended` keys, write the batch
-	// to engine.
-	if wbKeys >= WriteBatchMaxKeys {
-		return true
 	}
 
 	// Some commands may modify keys covered by the current write batch, so we

--- a/tikv/raftstore/applier.go
+++ b/tikv/raftstore/applier.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ngaut/log"
 	"github.com/ngaut/unistore/tikv/dbreader"
 	"github.com/ngaut/unistore/tikv/mvcc"
+	"github.com/ngaut/unistore/tikv/raftstore/raftlog"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/eraftpb"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
@@ -281,8 +282,6 @@ type applyContext struct {
 
 	// Indicates that WAL can be synchronized when data is written to KV engine.
 	enableSyncLog bool
-	// Whether synchronize WAL is preferred.
-	syncLogHint bool
 	// Whether to use the delete range API instead of deleting one by one.
 	useDeleteRange bool
 }
@@ -434,7 +433,11 @@ func notifyStaleReq(term uint64, cb *Callback) {
 }
 
 /// Checks if a write is needed to be issued before handling the command.
-func shouldWriteToEngine(cmd *raft_cmdpb.RaftCmdRequest, wbKeys int) bool {
+func shouldWriteToEngine(rlog raftlog.RaftLog, wbKeys int) bool {
+	cmd := rlog.GetRaftCmdRequest()
+	if cmd == nil {
+		return false
+	}
 	if cmd.AdminRequest != nil {
 		switch cmd.AdminRequest.CmdType {
 		case raft_cmdpb.AdminCmdType_ComputeHash, // ComputeHash require an up to date snapshot.
@@ -636,15 +639,22 @@ func (a *applier) handleRaftEntryNormal(aCtx *applyContext, entry *eraftpb.Entry
 	index := entry.Index
 	term := entry.Term
 	if len(entry.Data) > 0 {
-		cmd := new(raft_cmdpb.RaftCmdRequest)
-		err := cmd.Unmarshal(entry.Data)
-		if err != nil {
-			panic(err)
+		var rlog raftlog.RaftLog
+		if entry.Data[0] == raftlog.CustomRaftLogFlag {
+			rlog = raftlog.NewCustom(entry.Data)
+		} else {
+			cmd := new(raft_cmdpb.RaftCmdRequest)
+			err := cmd.Unmarshal(entry.Data)
+			if err != nil {
+				panic(err)
+			}
+			log.Info("cmd String", cmd.String())
+			rlog = raftlog.NewRequest(cmd)
 		}
-		if shouldWriteToEngine(cmd, len(aCtx.wb.entries)) {
+		if shouldWriteToEngine(rlog, len(aCtx.wb.entries)) {
 			aCtx.commit(a)
 		}
-		return a.processRaftCmd(aCtx, index, term, cmd)
+		return a.processRaftCmd(aCtx, index, term, rlog)
 	}
 
 	// when a peer become leader, it will send an empty entry.
@@ -675,7 +685,7 @@ func (a *applier) handleRaftEntryConfChange(aCtx *applyContext, entry *eraftpb.E
 	if err := cmd.Unmarshal(confChange.Context); err != nil {
 		panic(err)
 	}
-	result := a.processRaftCmd(aCtx, index, term, cmd)
+	result := a.processRaftCmd(aCtx, index, term, raftlog.NewRequest(cmd))
 	switch result.tp {
 	case applyResultTypeNone:
 		// If failed, tell Raft that the `ConfChange` was aborted.
@@ -718,15 +728,12 @@ func (a *applier) findCallback(index, term uint64, isConfChange bool) *Callback 
 	return nil
 }
 
-func (a *applier) processRaftCmd(aCtx *applyContext, index, term uint64, cmd *raft_cmdpb.RaftCmdRequest) applyResult {
+func (a *applier) processRaftCmd(aCtx *applyContext, index, term uint64, rlog raftlog.RaftLog) applyResult {
 	if index == 0 {
 		panic(fmt.Sprintf("%s process raft cmd need a none zero index", a.tag))
 	}
-	if cmd.AdminRequest != nil {
-		aCtx.syncLogHint = true
-	}
-	isConfChange := GetChangePeerCmd(cmd) != nil
-	resp, result := a.applyRaftCmd(aCtx, index, term, cmd)
+	isConfChange := GetChangePeerCmd(rlog.GetRaftCmdRequest()) != nil
+	resp, result := a.applyRaftCmd(aCtx, index, term, rlog)
 	if result.tp == applyResultTypeWaitMergeResource {
 		return result
 	}
@@ -749,13 +756,13 @@ func (a *applier) processRaftCmd(aCtx *applyContext, index, term uint64, cmd *ra
 /// we should try to apply the entry again or panic. Considering that this
 /// usually due to disk operation fail, which is rare, so just panic is ok.
 func (a *applier) applyRaftCmd(aCtx *applyContext, index, term uint64,
-	req *raft_cmdpb.RaftCmdRequest) (*raft_cmdpb.RaftCmdResponse, applyResult) {
+	rlog raftlog.RaftLog) (*raft_cmdpb.RaftCmdResponse, applyResult) {
 	// if pending remove, apply should be aborted already.
 	y.Assert(!a.pendingRemove)
 
 	aCtx.execCtx = a.newCtx(index, term)
 	aCtx.wb.SetSafePoint()
-	resp, applyResult, err := a.execRaftCmd(aCtx, req)
+	resp, applyResult, err := a.execRaftCmd(aCtx, rlog)
 	if err != nil {
 		// clear dirty values.
 		aCtx.wb.RollbackToSafePoint()
@@ -816,18 +823,20 @@ func (a *applier) newCtx(index, term uint64) *applyExecContext {
 }
 
 // Only errors that will also occur on all other stores should be returned.
-func (a *applier) execRaftCmd(aCtx *applyContext, req *raft_cmdpb.RaftCmdRequest) (
+func (a *applier) execRaftCmd(aCtx *applyContext, rlog raftlog.RaftLog) (
 	resp *raft_cmdpb.RaftCmdResponse, result applyResult, err error) {
 	// Include region for epoch not match after merge may cause key not in range.
-	includeRegion := req.Header.GetRegionEpoch().GetVersion() >= a.lastMergeVersion
-	err = checkRegionEpoch(req, a.region, includeRegion)
+	includeRegion := rlog.Epoch().Ver() >= a.lastMergeVersion
+	err = checkRegionEpoch(rlog, a.region, includeRegion)
 	if err != nil {
 		return
 	}
-	if req.AdminRequest != nil {
+	req := rlog.GetRaftCmdRequest()
+	if req.GetAdminRequest() != nil {
 		return a.execAdminCmd(aCtx, req)
 	}
-	return a.execWriteCmd(aCtx, req)
+	resp, result = a.execWriteCmd(aCtx, rlog)
+	return
 }
 
 func (a *applier) execAdminCmd(aCtx *applyContext, req *raft_cmdpb.RaftCmdRequest) (
@@ -872,8 +881,13 @@ func (a *applier) execAdminCmd(aCtx *applyContext, req *raft_cmdpb.RaftCmdReques
 	return
 }
 
-func (a *applier) execWriteCmd(aCtx *applyContext, req *raft_cmdpb.RaftCmdRequest) (
-	resp *raft_cmdpb.RaftCmdResponse, result applyResult, err error) {
+func (a *applier) execWriteCmd(aCtx *applyContext, rlog raftlog.RaftLog) (
+	resp *raft_cmdpb.RaftCmdResponse, result applyResult) {
+	if cl, ok := rlog.(*raftlog.CustomRaftLog); ok {
+		resp = a.execCustomLog(aCtx, cl)
+		return
+	}
+	req := rlog.GetRaftCmdRequest()
 	requests := req.GetRequests()
 	writeCmdOps := createWriteCmdOps(requests)
 	rangeDeleted := false
@@ -907,6 +921,39 @@ func (a *applier) execWriteCmd(aCtx *applyContext, req *raft_cmdpb.RaftCmdReques
 			data: &execResultDeleteRange{},
 		}
 	}
+	return
+}
+
+func (a *applier) execCustomLog(actx *applyContext, cl *raftlog.CustomRaftLog) (
+	resp *raft_cmdpb.RaftCmdResponse) {
+	var cnt int
+	switch cl.Type() {
+	case raftlog.TypePrewrite, raftlog.TypePessimisticLock:
+		cl.IterateLock(func(key, val []byte) {
+			actx.wb.SetLock(key, val)
+			cnt++
+		})
+	case raftlog.TypeCommit:
+		cl.IterateCommit(func(key, val []byte, commitTS uint64) {
+			a.commitLock(actx, key, val, commitTS)
+			cnt++
+		})
+	case raftlog.TypeRolback:
+		cl.IterateRollback(func(key []byte, deleteLock bool) {
+			actx.wb.Rollback(key)
+			if deleteLock {
+				actx.wb.DeleteLock(key[:len(key)-8])
+			}
+			cnt++
+		})
+	case raftlog.TypePessimisticRollback:
+		cl.IteratePessimisticRollback(func(key []byte) {
+			actx.wb.DeleteLock(key)
+			cnt++
+		})
+	}
+	resp = &raft_cmdpb.RaftCmdResponse{Header: &raft_cmdpb.RaftResponseHeader{}}
+	resp.Responses = make([]*raft_cmdpb.Response, cnt)
 	return
 }
 
@@ -1071,6 +1118,11 @@ func (a *applier) execCommit(aCtx *applyContext, op commitOp) {
 	}
 	val := a.getLock(aCtx, rawKey)
 	y.Assert(len(val) > 0)
+	a.commitLock(aCtx, rawKey, val, commitTS)
+	return
+}
+
+func (a *applier) commitLock(aCtx *applyContext, rawKey []byte, val []byte, commitTS uint64) {
 	lock := mvcc.DecodeLock(val)
 	var sizeDiff int64
 	userMeta := mvcc.NewDBUserMeta(lock.StartTS, commitTS)
@@ -1101,10 +1153,7 @@ func (a *applier) execCommit(aCtx *applyContext, op commitOp) {
 	if sizeDiff > 0 {
 		a.metrics.sizeDiffHint += uint64(sizeDiff)
 	}
-	if op.delLock != nil {
-		aCtx.wb.DeleteLock(rawKey, val)
-	}
-	return
+	aCtx.wb.DeleteLock(rawKey)
 }
 
 func (a *applier) getLock(aCtx *applyContext, rawKey []byte) []byte {
@@ -1128,7 +1177,7 @@ func (a *applier) execRollback(aCtx *applyContext, op rollbackOp) {
 		}
 		aCtx.wb.Rollback(append(rawKey, remain...))
 		if op.delLock != nil {
-			aCtx.wb.DeleteLock(rawKey, a.getLock(aCtx, rawKey))
+			aCtx.wb.DeleteLock(rawKey)
 		}
 		return
 	}
@@ -1137,7 +1186,7 @@ func (a *applier) execRollback(aCtx *applyContext, op rollbackOp) {
 		if err != nil {
 			panic(op.delLock.Key)
 		}
-		aCtx.wb.DeleteLock(rawKey, a.getLock(aCtx, rawKey))
+		aCtx.wb.DeleteLock(rawKey)
 	}
 }
 
@@ -1176,7 +1225,7 @@ func (a *applier) execDeleteRange(aCtx *applyContext, req *raft_cmdpb.DeleteRang
 		if bytes.Compare(lockIt.Key(), endKey) >= 0 {
 			break
 		}
-		aCtx.wb.DeleteLock(safeCopy(lockIt.Key()), safeCopy(lockIt.Key()))
+		aCtx.wb.DeleteLock(safeCopy(lockIt.Key()))
 	}
 	return
 }

--- a/tikv/raftstore/engine.go
+++ b/tikv/raftstore/engine.go
@@ -163,7 +163,7 @@ func (wb *WriteBatch) SetLock(key, val []byte) {
 	})
 }
 
-func (wb *WriteBatch) DeleteLock(key []byte, val []byte) {
+func (wb *WriteBatch) DeleteLock(key []byte) {
 	wb.lockEntries = append(wb.lockEntries, &badger.Entry{
 		Key:      key,
 		UserMeta: mvcc.LockUserMetaDelete,
@@ -390,7 +390,7 @@ func deleteLocksInBatch(db *mvcc.DBBundle, keys [][]byte, batchSize int) error {
 		keys = keys[batchSize:]
 		dbBatch := new(WriteBatch)
 		for _, key := range batchKeys {
-			dbBatch.DeleteLock(key, nil)
+			dbBatch.DeleteLock(key)
 		}
 		if err := dbBatch.WriteToKV(db); err != nil {
 			return err

--- a/tikv/raftstore/fsm_store.go
+++ b/tikv/raftstore/fsm_store.go
@@ -7,6 +7,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ngaut/unistore/tikv/raftstore/raftlog"
+
 	"github.com/coocood/badger"
 	"github.com/coocood/badger/y"
 	"github.com/ngaut/log"
@@ -772,7 +774,7 @@ func (d *storeMsgHandler) onComputeHashTick() {
 		CmdType: raft_cmdpb.AdminCmdType_ComputeHash,
 	}
 	cmd := &MsgRaftCmd{
-		Request: request,
+		Request: raftlog.NewRequest(request),
 	}
 	_ = d.ctx.router.sendRaftCommand(cmd)
 }

--- a/tikv/raftstore/msg.go
+++ b/tikv/raftstore/msg.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ngaut/unistore/tikv/raftstore/raftlog"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/raft_cmdpb"
 	"github.com/zhangjinpeng1987/raft"
@@ -126,7 +127,7 @@ type MsgSignificant struct {
 
 type MsgRaftCmd struct {
 	SendTime time.Time
-	Request  *raft_cmdpb.RaftCmdRequest
+	Request  raftlog.RaftLog
 	Callback *Callback
 }
 

--- a/tikv/raftstore/pd_task_handler.go
+++ b/tikv/raftstore/pd_task_handler.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/ngaut/unistore/tikv/raftstore/raftlog"
+
 	"github.com/ngaut/log"
 	"github.com/ngaut/unistore/pd"
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -262,14 +264,14 @@ func (r *pdTaskHandler) onDestroyPeer(t *pdDestroyPeerTask) {
 func (r *pdTaskHandler) sendAdminRequest(regionID uint64, epoch *metapb.RegionEpoch, peer *metapb.Peer, req *raft_cmdpb.AdminRequest, callback *Callback) {
 	cmd := &MsgRaftCmd{
 		SendTime: time.Now(),
-		Request: &raft_cmdpb.RaftCmdRequest{
+		Request: raftlog.NewRequest(&raft_cmdpb.RaftCmdRequest{
 			Header: &raft_cmdpb.RaftRequestHeader{
 				RegionId:    regionID,
 				Peer:        peer,
 				RegionEpoch: epoch,
 			},
 			AdminRequest: req,
-		},
+		}),
 		Callback: callback,
 	}
 	r.router.sendRaftCommand(cmd)

--- a/tikv/raftstore/peer_storage.go
+++ b/tikv/raftstore/peer_storage.go
@@ -614,7 +614,7 @@ func (ps *PeerStorage) Snapshot() (eraftpb.Snapshot, error) {
 	return snap, raft.ErrSnapshotTemporarilyUnavailable
 }
 
-// Append the given entries to the raft log using previous last index or self.last_index.
+// AppendLock the given entries to the raft log using previous last index or self.last_index.
 // Return the new last index for later update. After we commit in engine, we can set last_index
 // to the return one.
 func (ps *PeerStorage) Append(invokeCtx *InvokeContext, entries []eraftpb.Entry, raftWB *WriteBatch) error {

--- a/tikv/raftstore/peer_storage.go
+++ b/tikv/raftstore/peer_storage.go
@@ -614,7 +614,7 @@ func (ps *PeerStorage) Snapshot() (eraftpb.Snapshot, error) {
 	return snap, raft.ErrSnapshotTemporarilyUnavailable
 }
 
-// AppendLock the given entries to the raft log using previous last index or self.last_index.
+// Append the given entries to the raft log using previous last index or self.last_index.
 // Return the new last index for later update. After we commit in engine, we can set last_index
 // to the return one.
 func (ps *PeerStorage) Append(invokeCtx *InvokeContext, entries []eraftpb.Entry, raftWB *WriteBatch) error {

--- a/tikv/raftstore/peer_test.go
+++ b/tikv/raftstore/peer_test.go
@@ -1,9 +1,11 @@
 package raftstore
 
 import (
+	"testing"
+
+	"github.com/ngaut/unistore/tikv/raftstore/raftlog"
 	"github.com/pingcap/kvproto/pkg/raft_cmdpb"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestGetSyncLogFromRequest(t *testing.T) {
@@ -49,9 +51,9 @@ func TestIsUrgentRequest(t *testing.T) {
 		req.AdminRequest = new(raft_cmdpb.AdminRequest)
 		req.AdminRequest.CmdType = tp
 
-		assert.Equal(t, IsUrgentRequest(req), isUrgent)
+		assert.Equal(t, IsUrgentRequest(raftlog.NewRequest(req)), isUrgent)
 	}
-	assert.Equal(t, IsUrgentRequest(new(raft_cmdpb.RaftCmdRequest)), false)
+	assert.Equal(t, IsUrgentRequest(raftlog.NewRequest(new(raft_cmdpb.RaftCmdRequest))), false)
 }
 
 func TestEntryCtx(t *testing.T) {

--- a/tikv/raftstore/raftlog/custom.go
+++ b/tikv/raftstore/raftlog/custom.go
@@ -22,6 +22,8 @@ const (
 
 // CustomRaftLog is the raft log format for unistore to store Prewrite/Commit/PessimisticLock.
 //  | flag(1) | type(1) | version(2) | header(40) | entries
+//
+// It reduces the cost of marshal/unmarshal and avoid DB lookup during apply.
 type CustomRaftLog struct {
 	header *CustomHeader
 	Data   []byte

--- a/tikv/raftstore/raftlog/custom.go
+++ b/tikv/raftstore/raftlog/custom.go
@@ -1,0 +1,242 @@
+package raftlog
+
+import (
+	"encoding/binary"
+	"fmt"
+	"unsafe"
+
+	"github.com/pingcap/kvproto/pkg/raft_cmdpb"
+)
+
+type CustomRaftLogType byte
+
+const (
+	CustomRaftLogFlag byte = 64
+
+	TypePrewrite            CustomRaftLogType = 1
+	TypeCommit              CustomRaftLogType = 2
+	TypeRolback             CustomRaftLogType = 3
+	TypePessimisticLock     CustomRaftLogType = 4
+	TypePessimisticRollback CustomRaftLogType = 5
+)
+
+// CustomRaftLog is the raft log format for unistore to store Prewrite/Commit/PessimisticLock.
+//  | flag(1) | type(1) | version(2) | header(40) | entries
+type CustomRaftLog struct {
+	header *CustomHeader
+	Data   []byte
+}
+
+func NewCustom(data []byte) *CustomRaftLog {
+	rlog := &CustomRaftLog{}
+	rlog.header = (*CustomHeader)(unsafe.Pointer(&data[4]))
+	rlog.Data = data
+	return rlog
+}
+
+func (c *CustomRaftLog) Type() CustomRaftLogType {
+	return CustomRaftLogType(c.Data[1])
+}
+
+func (c *CustomRaftLog) RegionID() uint64 {
+	return c.header.RegionID
+}
+
+func (c *CustomRaftLog) PeerID() uint64 {
+	return c.header.PeerID
+}
+
+func (c *CustomRaftLog) StoreID() uint64 {
+	return c.header.StoreID
+}
+
+func (c *CustomRaftLog) Epoch() Epoch {
+	return c.header.Epoch
+}
+
+func (c *CustomRaftLog) Term() uint64 {
+	return c.header.Term
+}
+
+func (c *CustomRaftLog) Marshal() []byte {
+	return c.Data
+}
+
+func (c *CustomRaftLog) GetRaftCmdRequest() *raft_cmdpb.RaftCmdRequest {
+	return nil
+}
+
+type CustomHeader struct {
+	RegionID uint64
+	Epoch    Epoch
+	PeerID   uint64
+	StoreID  uint64
+	Term     uint64
+}
+
+const headerSize = int(unsafe.Sizeof(CustomHeader{}))
+
+func (h *CustomHeader) Marshal() []byte {
+	data := make([]byte, headerSize)
+	*(*CustomHeader)(unsafe.Pointer(&data[0])) = *h
+	return data
+}
+
+type Epoch struct {
+	ver     uint32
+	confVer uint32
+}
+
+func NewEpoch(ver, confVer uint64) Epoch {
+	return Epoch{ver: uint32(ver), confVer: uint32(confVer)}
+}
+
+func (e Epoch) Ver() uint64 {
+	return uint64(e.ver)
+}
+
+func (e Epoch) ConfVer() uint64 {
+	return uint64(e.confVer)
+}
+
+func (e Epoch) String() string {
+	return fmt.Sprintf("{Ver:%d, ConfVer:%d}", e.ver, e.confVer)
+}
+
+func (rl *CustomRaftLog) IterateLock(itFunc func(key, val []byte)) {
+	i := 4 + headerSize
+	for i < len(rl.Data) {
+		keyLen := endian.Uint16(rl.Data[i:])
+		i += 2
+		key := rl.Data[i : i+int(keyLen)]
+		i += int(keyLen)
+		valLen := endian.Uint32(rl.Data[i:])
+		i += 4
+		val := rl.Data[i : i+int(valLen)]
+		i += int(valLen)
+		itFunc(key, val)
+	}
+}
+
+func (rl *CustomRaftLog) IterateCommit(itFunc func(key, val []byte, commitTS uint64)) {
+	i := 4 + headerSize
+	for i < len(rl.Data) {
+		keyLen := endian.Uint16(rl.Data[i:])
+		i += 2
+		key := rl.Data[i : i+int(keyLen)]
+		i += int(keyLen)
+		valLen := endian.Uint32(rl.Data[i:])
+		i += 4
+		val := rl.Data[i : i+int(valLen)]
+		i += int(valLen)
+		commitTS := endian.Uint64(rl.Data[i:])
+		i += 8
+		itFunc(key, val, commitTS)
+	}
+}
+
+func (rl *CustomRaftLog) IterateRollback(itFunc func(key []byte, deleteLock bool)) {
+	i := 4 + headerSize
+	for i < len(rl.Data) {
+		keyLen := endian.Uint16(rl.Data[i:])
+		i += 2
+		key := rl.Data[i : i+int(keyLen)]
+		i += int(keyLen)
+		del := rl.Data[i]
+		i++
+		itFunc(key, del > 0)
+	}
+}
+
+func (rl *CustomRaftLog) IteratePessimisticRollback(itFunc func(key []byte)) {
+	i := 4 + headerSize
+	for i < len(rl.Data) {
+		keyLen := endian.Uint16(rl.Data[i:])
+		i += 2
+		key := rl.Data[i : i+int(keyLen)]
+		i += int(keyLen)
+		itFunc(key)
+	}
+}
+
+type CustomBuilder struct {
+	data []byte
+	cnt  int
+}
+
+func NewBuilder(header CustomHeader) *CustomBuilder {
+	b := &CustomBuilder{}
+	b.data = append(b.data, CustomRaftLogFlag, 0, 0, 0)
+	b.data = append(b.data, header.Marshal()...)
+	return b
+}
+
+func (b *CustomBuilder) AppendLock(key, value []byte) {
+	b.data = append(b.data, u16ToBytes(uint16(len(key)))...)
+	b.data = append(b.data, key...)
+	b.data = append(b.data, u32ToBytes(uint32(len(value)))...)
+	b.data = append(b.data, value...)
+	b.cnt++
+}
+
+func (b *CustomBuilder) AppendCommit(key, value []byte, commitTS uint64) {
+	b.data = append(b.data, u16ToBytes(uint16(len(key)))...)
+	b.data = append(b.data, key...)
+	b.data = append(b.data, u32ToBytes(uint32(len(value)))...)
+	b.data = append(b.data, value...)
+	b.data = append(b.data, u64ToBytes(commitTS)...)
+	b.cnt++
+}
+
+func (b *CustomBuilder) AppendRollback(key []byte, deleteLock bool) {
+	b.data = append(b.data, u16ToBytes(uint16(len(key)))...)
+	b.data = append(b.data, key...)
+	if deleteLock {
+		b.data = append(b.data, 1)
+	} else {
+		b.data = append(b.data, 0)
+	}
+	b.cnt++
+}
+
+func (b *CustomBuilder) AppendPessimisticRollback(key []byte) {
+	b.data = append(b.data, u16ToBytes(uint16(len(key)))...)
+	b.data = append(b.data, key...)
+	b.cnt++
+}
+
+func (b *CustomBuilder) SetType(tp CustomRaftLogType) {
+	b.data[1] = byte(tp)
+}
+
+func (b *CustomBuilder) GetType() CustomRaftLogType {
+	return CustomRaftLogType(b.data[1])
+}
+
+func (b *CustomBuilder) Build() *CustomRaftLog {
+	return NewCustom(b.data)
+}
+
+func (b *CustomBuilder) Len() int {
+	return b.cnt
+}
+
+var endian = binary.LittleEndian
+
+func u16ToBytes(v uint16) []byte {
+	b := make([]byte, 2)
+	endian.PutUint16(b, v)
+	return b
+}
+
+func u32ToBytes(v uint32) []byte {
+	b := make([]byte, 4)
+	endian.PutUint32(b, v)
+	return b
+}
+
+func u64ToBytes(v uint64) []byte {
+	b := make([]byte, 8)
+	endian.PutUint64(b, v)
+	return b
+}

--- a/tikv/raftstore/raftlog/raftlog.go
+++ b/tikv/raftstore/raftlog/raftlog.go
@@ -1,0 +1,13 @@
+package raftlog
+
+import "github.com/pingcap/kvproto/pkg/raft_cmdpb"
+
+type RaftLog interface {
+	RegionID() uint64
+	Epoch() Epoch
+	PeerID() uint64
+	StoreID() uint64
+	Term() uint64
+	Marshal() []byte
+	GetRaftCmdRequest() *raft_cmdpb.RaftCmdRequest
+}

--- a/tikv/raftstore/raftlog/request.go
+++ b/tikv/raftstore/raftlog/request.go
@@ -1,0 +1,51 @@
+package raftlog
+
+import "github.com/pingcap/kvproto/pkg/raft_cmdpb"
+
+type RequestRaftLog struct {
+	*raft_cmdpb.RaftCmdRequest
+}
+
+func (r RequestRaftLog) RegionID() uint64 {
+	return r.Header.RegionId
+}
+
+func (r RequestRaftLog) Epoch() Epoch {
+	e := r.Header.RegionEpoch
+	if e == nil {
+		return Epoch{}
+	}
+	return Epoch{ver: uint32(e.Version), confVer: uint32(e.ConfVer)}
+}
+
+func (r RequestRaftLog) RegionConfVer() uint64 {
+	return r.Header.RegionEpoch.ConfVer
+}
+
+func (r RequestRaftLog) StoreID() uint64 {
+	return r.Header.Peer.StoreId
+}
+
+func (r RequestRaftLog) PeerID() uint64 {
+	return r.Header.Peer.Id
+}
+
+func (r RequestRaftLog) Term() uint64 {
+	return r.Header.Term
+}
+
+func (r RequestRaftLog) GetRaftCmdRequest() *raft_cmdpb.RaftCmdRequest {
+	return r.RaftCmdRequest
+}
+
+func (r RequestRaftLog) Marshal() []byte {
+	data, err := r.RaftCmdRequest.Marshal()
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+func NewRequest(req *raft_cmdpb.RaftCmdRequest) RaftLog {
+	return RequestRaftLog{RaftCmdRequest: req}
+}

--- a/tikv/raftstore/raftstore_router.go
+++ b/tikv/raftstore/raftstore_router.go
@@ -3,6 +3,7 @@ package raftstore
 import (
 	"time"
 
+	"github.com/ngaut/unistore/tikv/raftstore/raftlog"
 	"github.com/pingcap/kvproto/pkg/raft_cmdpb"
 	"github.com/pingcap/kvproto/pkg/raft_serverpb"
 	"github.com/zhangjinpeng1987/raft"
@@ -25,7 +26,7 @@ func (r *RaftstoreRouter) SendCommand(req *raft_cmdpb.RaftCmdRequest, cb *Callba
 	// TODO: support local reader
 	msg := &MsgRaftCmd{
 		SendTime: time.Now(),
-		Request:  req,
+		Request:  raftlog.NewRequest(req),
 		Callback: cb,
 	}
 	return r.router.sendRaftCommand(msg)

--- a/tikv/raftstore/restore_test.go
+++ b/tikv/raftstore/restore_test.go
@@ -49,7 +49,7 @@ func TestRestore(t *testing.T) {
 		Primary: k1,
 		Value:   v1,
 	}
-	wb.Prewrite(k1, &expectLock, false)
+	wb.Prewrite(k1, &expectLock)
 	txn := engines.kv.DB.NewTransaction(true)
 	err := restoreAppliedEntry(genEntry(wb, t), txn, lockStore, rollbackStore)
 	require.Nil(t, err)

--- a/tikv/raftstore/router.go
+++ b/tikv/raftstore/router.go
@@ -71,7 +71,7 @@ func (pr *router) send(regionID uint64, msg Msg) error {
 }
 
 func (pr *router) sendRaftCommand(cmd *MsgRaftCmd) error {
-	regionID := cmd.Request.Header.RegionId
+	regionID := cmd.Request.RegionID()
 	return pr.send(regionID, NewPeerMsg(MsgTypeRaftCmd, regionID, cmd))
 }
 

--- a/tikv/write.go
+++ b/tikv/write.go
@@ -288,10 +288,7 @@ type writeBatch struct {
 	lockBatch writeLockBatch
 }
 
-func (wb *writeBatch) Prewrite(key []byte, lock *mvcc.MvccLock, isPessimisticLock bool) {
-	if isPessimisticLock {
-		wb.lockBatch.delete(key)
-	}
+func (wb *writeBatch) Prewrite(key []byte, lock *mvcc.MvccLock) {
 	wb.lockBatch.set(key, lock.MarshalBinary())
 }
 


### PR DESCRIPTION
The custom raft log format is optional, we can still build TiKV compatible raft log.

After this optimization, the batch insert performance is doubled, exceeds the latest tikv.

Tested on a 40 core linux server

```
create table t (id bigint primary key auto_increment, c bigint)
```

Then run 8 workers do

```
for {
     insert t (c) values ... // 500 rows
}
```

TiKV:
```
177000
185500
184500
178500
179000
181000
176000
182500
179500
177000
178000
178500
173500
177000
183000
176000
177500
179000
178500
185000
184000
183500
```

Unistore:
```
255000
227000
227000
233500
234500
255500
247000
209000
252500
257000
254500
256500
214500
264500
243000
256000
257500
```
