### PR TITLE
lockstore support PutWithHint and DeleleWithHint

### DIFF
--- a/tikv/mvcc.go
+++ b/tikv/mvcc.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"math"
 	"os"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -157,8 +158,30 @@ func (store *MVCCStore) getDBItems(reqCtx *requestCtx, mutations []*kvrpcpb.Muta
 	return txn.MultiGet(keys)
 }
 
+func sortMutations(mutations []*kvrpcpb.Mutation) []*kvrpcpb.Mutation {
+	fn := func(i, j int) bool {
+		return bytes.Compare(mutations[i].Key, mutations[j].Key) < 0
+	}
+	if sort.SliceIsSorted(mutations, fn) {
+		return mutations
+	}
+	sort.Slice(mutations, fn)
+	return mutations
+}
+
+func sortKeys(keys [][]byte) [][]byte {
+	less := func(i, j int) bool {
+		return bytes.Compare(keys[i], keys[j]) < 0
+	}
+	if sort.SliceIsSorted(keys, less) {
+		return keys
+	}
+	sort.Slice(keys, less)
+	return keys
+}
+
 func (store *MVCCStore) PessimisticLock(reqCtx *requestCtx, req *kvrpcpb.PessimisticLockRequest) (*lockwaiter.Waiter, error) {
-	mutations := req.Mutations
+	mutations := sortMutations(req.Mutations)
 	startTS := req.StartVersion
 	regCtx := reqCtx.regCtx
 	hashVals := mutationsToHashVals(mutations)
@@ -201,7 +224,7 @@ func (store *MVCCStore) PessimisticLock(reqCtx *requestCtx, req *kvrpcpb.Pessimi
 }
 
 func (store *MVCCStore) PessimisticRollback(reqCtx *requestCtx, req *kvrpcpb.PessimisticRollbackRequest) error {
-	keys := req.Keys
+	keys := sortKeys(req.Keys)
 	hashVals := keysToHashVals(keys...)
 	regCtx := reqCtx.regCtx
 	regCtx.AcquireLatches(hashVals)
@@ -370,7 +393,7 @@ func (store *MVCCStore) buildPessimisticLock(m *kvrpcpb.Mutation, item *badger.I
 }
 
 func (store *MVCCStore) Prewrite(reqCtx *requestCtx, req *kvrpcpb.PrewriteRequest) error {
-	mutations := req.Mutations
+	mutations := sortMutations(req.Mutations)
 	regCtx := reqCtx.regCtx
 	hashVals := mutationsToHashVals(mutations)
 
@@ -585,6 +608,7 @@ const maxSystemTS uint64 = math.MaxUint64
 
 // Commit implements the MVCCStore interface.
 func (store *MVCCStore) Commit(req *requestCtx, keys [][]byte, startTS, commitTS uint64) error {
+	sortKeys(keys)
 	store.updateLatestTS(commitTS)
 	regCtx := req.regCtx
 	hashVals := keysToHashVals(keys...)
@@ -668,6 +692,7 @@ const (
 )
 
 func (store *MVCCStore) Rollback(reqCtx *requestCtx, keys [][]byte, startTS uint64) error {
+	sortKeys(keys)
 	hashVals := keysToHashVals(keys...)
 	log.Warnf("%d rollback %v", startTS, hashVals)
 	regCtx := reqCtx.regCtx

--- a/tikv/raftstore/applier.go
+++ b/tikv/raftstore/applier.go
@@ -641,7 +641,6 @@ func (a *applier) handleRaftEntryNormal(aCtx *applyContext, entry *eraftpb.Entry
 			if err != nil {
 				panic(err)
 			}
-			log.Info("cmd String", cmd.String())
 			rlog = raftlog.NewRequest(cmd)
 		}
 		if shouldWriteToEngine(rlog, len(aCtx.wb.entries)) {

--- a/tikv/write.go
+++ b/tikv/write.go
@@ -167,9 +167,7 @@ func (w writeLockWorker) run() {
 					rollbackStore.Delete(entry.Key)
 				default:
 					insertCnt++
-					if !ls.PutWithHint(entry.Key, entry.Value, hint) {
-						panic("failed to insert key")
-					}
+					ls.PutWithHint(entry.Key, entry.Value, hint)
 				}
 			}
 			batch.wg.Done()

--- a/tikv/write.go
+++ b/tikv/write.go
@@ -7,12 +7,12 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/cznic/mathutil"
-	"github.com/ngaut/unistore/tikv/dbreader"
-	"github.com/pingcap/kvproto/pkg/kvrpcpb"
-
 	"github.com/coocood/badger"
+	"github.com/cznic/mathutil"
+	"github.com/ngaut/unistore/lockstore"
+	"github.com/ngaut/unistore/tikv/dbreader"
 	"github.com/ngaut/unistore/tikv/mvcc"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 )
 
 const (
@@ -151,6 +151,7 @@ func (w writeLockWorker) run() {
 		for i := 0; i < chLen; i++ {
 			batches = append(batches, <-w.batchCh)
 		}
+		hint := new(lockstore.Hint)
 		var delCnt, insertCnt int
 		for _, batch := range batches {
 			for _, entry := range batch.entries {
@@ -159,14 +160,14 @@ func (w writeLockWorker) run() {
 					rollbackStore.Put(entry.Key, []byte{0})
 				case mvcc.LockUserMetaDeleteByte:
 					delCnt++
-					if !ls.Delete(entry.Key) {
+					if !ls.DeleteWithHint(entry.Key, hint) {
 						panic("failed to delete key")
 					}
 				case mvcc.LockUserMetaRollbackGCByte:
 					rollbackStore.Delete(entry.Key)
 				default:
 					insertCnt++
-					if !ls.Put(entry.Key, entry.Value) {
+					if !ls.PutWithHint(entry.Key, entry.Value, hint) {
 						panic("failed to insert key")
 					}
 				}


### PR DESCRIPTION
The sequential batch insert performance increased by about 50%

```
358600
376400
369000
287200
379800
377200
358200
309200
367400
377000
315600
370000
384600
374000
288400
382400
397800
365200
305800
382000
```