### PR TITLE
add wake up delay duration, optimize wake up

### DIFF
--- a/config/config-template.toml
+++ b/config/config-template.toml
@@ -77,3 +77,6 @@ region-split-keys = 960000
 # The default and maximum delay in milliseconds before responding to TiDB when pessimistic
 # transactions encounter locks, in milliseconds
 wait-for-lock-timeout = 1000
+
+# The duration between waking up lock waiter, in miliseconds
+wake-up-delay-duration = 100

--- a/config/config.go
+++ b/config/config.go
@@ -63,6 +63,9 @@ type PessimisticTxn struct {
 	// The default and maximum delay in milliseconds before responding to TiDB when pessimistic
 	// transactions encounter locks
 	WaitForLockTimeout int64 `toml:"wait-for-lock-timeout"`
+
+	// The duration between waking up lock waiter, in milliseconds
+	WakeUpDelayDuration int64 `toml:"wake-up-delay-duration"`
 }
 
 func ParseCompression(s string) options.CompressionType {
@@ -116,7 +119,8 @@ var DefaultConf = Config{
 		RegionSplitKeys: 960000,
 	},
 	PessimisticTxn: PessimisticTxn{
-		WaitForLockTimeout: 1000, // 1000ms same with tikv default value
+		WaitForLockTimeout:  1000, // 1000ms same with tikv default value
+		WakeUpDelayDuration: 300,  // 100ms same with tikv default value
 	},
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -120,7 +120,7 @@ var DefaultConf = Config{
 	},
 	PessimisticTxn: PessimisticTxn{
 		WaitForLockTimeout:  1000, // 1000ms same with tikv default value
-		WakeUpDelayDuration: 300,  // 100ms same with tikv default value
+		WakeUpDelayDuration: 100,  // 100ms same with tikv default value
 	},
 }
 

--- a/tikv/server.go
+++ b/tikv/server.go
@@ -214,16 +214,7 @@ func (svr *Server) KvPessimisticLock(ctx context.Context, req *kvrpcpb.Pessimist
 		return resp, nil
 	}
 	if result.WakeupSleepTime != lockwaiter.WakeUpThisWaiter {
-		// wait as config "wake-up-delay-duration" specified, the oldest waiter won't sleep and will be more likely
-		// to get the lock
-		waiter.SetTimeout(time.Duration(result.WakeupSleepTime) * time.Millisecond)
-		waitRes := waiter.Wait()
-		if waitRes.WakeupSleepTime != lockwaiter.WakeUpThisWaiter {
-			svr.mvccStore.lockWaiterManager.CleanUp(waiter)
-		}
-		if waitRes.CommitTS > result.CommitTS {
-			result.CommitTS = waitRes.CommitTS
-		}
+		svr.mvccStore.lockWaiterManager.CleanUp(waiter)
 	}
 	conflictCommitTS := result.CommitTS
 	if conflictCommitTS < req.GetForUpdateTs() {

--- a/util/lockwaiter/lockwaiter.go
+++ b/util/lockwaiter/lockwaiter.go
@@ -83,7 +83,7 @@ func (w *Waiter) Wait() WaitResult {
 			}
 			return WaitResult{WakeupSleepTime: WaitTimeout}
 		case result := <-w.ch:
-			if result.WakeupSleepTime != WakeUpThisWaiter {
+			if result.WakeupSleepTime == WakeupDelayTimeout {
 				// wait as config "wake-up-delay-duration" specified, the oldest waiter won't sleep and
 				// will be more likely  to get the lock
 				delaySleepDuration := time.Duration(result.WakeupSleepTime) * time.Millisecond

--- a/util/lockwaiter/lockwaiter.go
+++ b/util/lockwaiter/lockwaiter.go
@@ -88,7 +88,9 @@ func (w *Waiter) Wait() WaitResult {
 				// will be more likely  to get the lock
 				delaySleepDuration := time.Duration(result.WakeupSleepTime) * time.Millisecond
 				if time.Now().Add(delaySleepDuration).Before(w.deadlineTime) {
-					w.timer.Reset(delaySleepDuration)
+					if w.timer.Stop() {
+						w.timer.Reset(delaySleepDuration)
+					}
 				}
 				w.CommitTs = result.CommitTS
 				continue

--- a/util/lockwaiter/lockwaiter_test.go
+++ b/util/lockwaiter/lockwaiter_test.go
@@ -89,7 +89,7 @@ func (t *testLockwaiter) TestLockwaiterConcurrent(c *C) {
 				mgr.CleanUp(waiter)
 				wg.Done()
 				res := waiter.Wait()
-				c.Assert(res.Position, Equals, WaitTimeout)
+				c.Assert(res.WakeupSleepTime, Equals, WaitTimeout)
 				c.Assert(res.CommitTS, Equals, uint64(0))
 				c.Assert(res.DeadlockResp, IsNil)
 			} else {


### PR DESCRIPTION
Add wakeup delay duration config,  wakeup the oldest lock waiter first

1. Make the lock wait wakeup ordering by txn startTs as many as possible
2. Optimize hot-update perfomance on single row

sysbench oltp_hot_update 512 thread on single row `update wm set v = v + 1 where id = 1`

master
```
SQL statistics:
    queries performed:
        read:                            0
        write:                           47942
        other:                           95884
        total:                           143826
    transactions:                        47942  (395.09 per sec.)
    queries:                             143826 (1185.26 per sec.)
    ignored errors:                      0      (0.00 per sec.)
    reconnects:                          0      (0.00 per sec.)

General statistics:
    total time:                          121.3436s
    total number of events:              47942

Latency (ms):
         min:                                    1.53
         avg:                                 1288.70
         max:                                21449.29
         95th percentile:                     5124.81
         sum:                             61782775.52

Threads fairness:
    events (avg/stddev):           93.6367/14.23
    execution time (avg/stddev):   120.6695/0.39
```

dev
```
SQL statistics:
    queries performed:
        read:                            0
        write:                           68559
        other:                           137118
        total:                           205677
    transactions:                        68559  (567.04 per sec.)
    queries:                             205677 (1701.12 per sec.)
    ignored errors:                      0      (0.00 per sec.)
    reconnects:                          0      (0.00 per sec.)

General statistics:
    total time:                          120.9052s
    total number of events:              68559

Latency (ms):
         min:                                    1.91
         avg:                                  899.52
         max:                                  998.28
         95th percentile:                      943.16
         sum:                             61670385.75

Threads fairness:
    events (avg/stddev):           133.9043/0.36
    execution time (avg/stddev):   120.4500/0.26

```

