### PR TITLE
refactor latch new implementation

### DIFF
--- a/tikv/cop_handler_test.go
+++ b/tikv/cop_handler_test.go
@@ -45,7 +45,7 @@ type encodedTestKVData struct {
 func initTestData(store *TestStore, encodedKVDatas []*encodedTestKVData) []error {
 	reqCtx := requestCtx{
 		regCtx: &regionCtx{
-			latches: make(map[uint64]*sync.WaitGroup),
+			latches: new(sync.Map),
 		},
 		svr: store.Svr,
 	}

--- a/tikv/mvcc_test.go
+++ b/tikv/mvcc_test.go
@@ -40,7 +40,7 @@ func (ts *TestStore) newReqCtx() *requestCtx {
 func (ts *TestStore) newReqCtxWithKeys(startKey, endKey []byte) *requestCtx {
 	return &requestCtx{
 		regCtx: &regionCtx{
-			latches:  make(map[uint64]*sync.WaitGroup),
+			latches:  new(sync.Map),
 			startKey: startKey,
 			endKey:   endKey,
 		},

--- a/tikv/region.go
+++ b/tikv/region.go
@@ -143,7 +143,6 @@ func (ri *regionCtx) marshal() []byte {
 }
 
 func (ri *regionCtx) tryAcquireLatches(hashVals []uint64) {
-	log.Infof("[for debug] try ac k=%v", hashVals)
 	wg := new(sync.WaitGroup)
 	wg.Add(1)
 	for _, hashVal := range hashVals {
@@ -151,12 +150,9 @@ func (ri *regionCtx) tryAcquireLatches(hashVals []uint64) {
 			res, loaded := ri.latches.LoadOrStore(hashVal, wg)
 			if loaded {
 				resWg := res.(*sync.WaitGroup)
-				log.Infof("[for debug] loaded found, wait")
 				resWg.Wait()
-				log.Infof("[for debug] wait wakeup retry LoadOrStore")
 				continue
 			}
-			log.Infof("[for debug] latch got for k=%v", hashVal)
 			break
 		}
 	}

--- a/tikv/region.go
+++ b/tikv/region.go
@@ -3,7 +3,6 @@ package tikv
 import (
 	"bytes"
 	"encoding/binary"
-	"sort"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -165,19 +164,6 @@ func (ri *regionCtx) AcquireLatches(hashVals []uint64) {
 		log.Errorf("hashVals array length equals 0")
 		return
 	}
-	// Make sure hashVals in sort ascending order and no duplicates
-	sort.Slice(hashVals, func(i, j int) bool {
-		return hashVals[i] < hashVals[j]
-	})
-	idx := 0
-	for i, v := range hashVals {
-		if i > 0 && hashVals[i] == hashVals[i-1] {
-			continue
-		}
-		hashVals[idx] = v
-		idx++
-	}
-	hashVals = hashVals[0:idx]
 	start := time.Now()
 	ri.tryAcquireLatches(hashVals)
 	dur := time.Since(start)

--- a/tikv/util.go
+++ b/tikv/util.go
@@ -2,6 +2,7 @@ package tikv
 
 import (
 	"bytes"
+	"sort"
 	"time"
 
 	"github.com/dgryski/go-farm"
@@ -23,11 +24,31 @@ func tsSub(tsA, tsB uint64) time.Duration {
 	return time.Duration(tsAPhysical-tsBPhysical) * time.Millisecond
 }
 
+// SortAndDedupHashVals will change hashVals into sort ascending order and remove duplicates
+func sortAndDedupHashVals(hashVals []uint64) []uint64 {
+	if len(hashVals) > 1 {
+		sort.Slice(hashVals, func(i, j int) bool {
+			return hashVals[i] < hashVals[j]
+		})
+		idx := 0
+		for i, v := range hashVals {
+			if i > 0 && hashVals[i] == hashVals[i-1] {
+				continue
+			}
+			hashVals[idx] = v
+			idx++
+		}
+		hashVals = hashVals[0:idx]
+	}
+	return hashVals
+}
+
 func mutationsToHashVals(mutations []*kvrpcpb.Mutation) []uint64 {
 	hashVals := make([]uint64, len(mutations))
 	for i, mut := range mutations {
 		hashVals[i] = farm.Fingerprint64(mut.Key)
 	}
+	hashVals = sortAndDedupHashVals(hashVals)
 	return hashVals
 }
 
@@ -36,6 +57,7 @@ func keysToHashVals(keys ...[]byte) []uint64 {
 	for i, key := range keys {
 		hashVals[i] = farm.Fingerprint64(key)
 	}
+	hashVals = sortAndDedupHashVals(hashVals)
 	return hashVals
 }
 


### PR DESCRIPTION
Change latch map to `sync.Map`, remove the latch mutex

Some bench under `master` and `dev`(without wakeup delay duration change)
Acquire latch cost reduces

Some bench on latch aquire and release will be done later in this post
```
master
SQL statistics:
    queries performed:
        read:                            0
        write:                           46940
        other:                           93880
        total:                           140820
    transactions:                        46940  (387.07 per sec.)
    queries:                             140820 (1161.20 per sec.)
    ignored errors:                      0      (0.00 per sec.)
    reconnects:                          0      (0.00 per sec.)

General statistics:
    total time:                          121.2696s
    total number of events:              46940

Latency (ms):
         min:                                    1.51
         avg:                                 1315.83
         max:                                18166.54
         95th percentile:                     5312.73
         sum:                             61765103.84
```

```
dev
SQL statistics:
    queries performed:
        read:                            0
        write:                           56810
        other:                           113620
        total:                           170430
    transactions:                        56810  (468.61 per sec.)
    queries:                             170430 (1405.83 per sec.)
    ignored errors:                      0      (0.00 per sec.)
    reconnects:                          0      (0.00 per sec.)

General statistics:
    total time:                          121.2287s
    total number of events:              56810

Latency (ms):
         min:                                    1.50
         avg:                                 1087.00
         max:                                17766.62
         95th percentile:                     4358.09
         sum:                             61752605.71

Threads fairness:
    events (avg/stddev):           110.9570/14.32
    execution time (avg/stddev):   120.6106/0.36

```
