### PR TITLE
server: return lock type when error locked

### DIFF
--- a/tikv/errors.go
+++ b/tikv/errors.go
@@ -7,15 +7,28 @@ import (
 // ErrLocked is returned when trying to Read/Write on a locked key. Client should
 // backoff or cleanup the lock then retry.
 type ErrLocked struct {
-	Key     []byte
-	Primary []byte
-	StartTS uint64
-	TTL     uint64
+	Key      []byte
+	Primary  []byte
+	StartTS  uint64
+	TTL      uint64
+	LockType uint8
+}
+
+// BuildLockErr generates ErrKeyLocked objects
+func BuildLockErr(key []byte, primaryKey []byte, startTS uint64, TTL uint64, lockType uint8) *ErrLocked {
+	errLocked := &ErrLocked{
+		Key:      key,
+		Primary:  primaryKey,
+		StartTS:  startTS,
+		TTL:      TTL,
+		LockType: lockType,
+	}
+	return errLocked
 }
 
 // Error formats the lock to a string.
 func (e *ErrLocked) Error() string {
-	return fmt.Sprintf("key is locked, key: %q, primary: %q, startTS: %v", e.Key, e.Primary, e.StartTS)
+	return fmt.Sprintf("key is locked, key: %q, Type: %v, primary: %q, startTS: %v", e.Key, e.LockType, e.Primary, e.StartTS)
 }
 
 // ErrRetryable suggests that client may restart the txn. e.g. write conflict.

--- a/tikv/server.go
+++ b/tikv/server.go
@@ -638,6 +638,7 @@ func convertToKeyError(err error) *kvrpcpb.KeyError {
 				PrimaryLock: x.Primary,
 				LockVersion: x.StartTS,
 				LockTtl:     x.TTL,
+				LockType:    kvrpcpb.Op(x.LockType),
 			},
 		}
 	case ErrRetryable:


### PR DESCRIPTION

The lock error should return lock type,  otherwise `tidb` lock resolver will get into dead loop keep reporting `txn not found`

`tps` in sysbench tests sometimes  will get into 0 and last for 20s(default lock TTL), because of the missing lock type like `pessimistic lock`