### PR TITLE
txn: check key commited from store if lock not found

### DIFF
--- a/tikv/mvcc.go
+++ b/tikv/mvcc.go
@@ -638,11 +638,10 @@ func (store *MVCCStore) Commit(req *requestCtx, keys [][]byte, startTS, commitTS
 	var buf []byte
 	var tmpDiff int
 	var isPessimisticTxn bool
-	var lockErr error
-	var checkErr error
-	var lock mvcc.MvccLock
 	for _, key := range keys {
-		lockErr = nil
+		var lockErr error
+		var checkErr error
+		var lock mvcc.MvccLock
 		buf = store.lockStore.Get(key, buf)
 		if len(buf) == 0 {
 			// We never commit partial keys in Commit request, so if one lock is not found,

--- a/tikv/raftstore/applier.go
+++ b/tikv/raftstore/applier.go
@@ -972,9 +972,11 @@ type rollbackOp struct {
 // createWriteCmdOps regroups requests into operations.
 func createWriteCmdOps(requests []*raft_cmdpb.Request) (ops []interface{}) {
 	// If first request is delete write, then this is a GC command, we can ignore it.
-	if del := requests[0].Delete; del != nil {
-		if del.Cf == CFWrite {
-			return
+	if len(requests) > 0 {
+		if del := requests[0].Delete; del != nil {
+			if del.Cf == CFWrite {
+				return
+			}
 		}
 	}
 	for i := 0; i < len(requests); i++ {


### PR DESCRIPTION
Issue #328 

Do not let `tidb` report partial commit error log during benchmark tests