### PR TITLE
fix panic when restore lockStore data from raft log.

### DIFF
--- a/tikv/raftstore/engine.go
+++ b/tikv/raftstore/engine.go
@@ -261,9 +261,7 @@ func (wb *WriteBatch) WriteToKV(bundle *mvcc.DBBundle) error {
 			case mvcc.LockUserMetaRollbackByte:
 				bundle.RollbackStore.Put(entry.Key, []byte{0})
 			case mvcc.LockUserMetaDeleteByte:
-				if !bundle.LockStore.DeleteWithHint(entry.Key, hint) {
-					panic("failed to delete key")
-				}
+				bundle.LockStore.DeleteWithHint(entry.Key, hint)
 			case mvcc.LockUserMetaRollbackGCByte:
 				bundle.RollbackStore.Delete(entry.Key)
 			default:


### PR DESCRIPTION
When we restore lockStore from raft log, it’s normal that the DeleteLock deleting a non-exist key.