### PR TITLE
fix memory leak

### DIFF
--- a/tikv/raftstore/applier.go
+++ b/tikv/raftstore/applier.go
@@ -1481,15 +1481,7 @@ func (a *applier) execCompactLog(aCtx *applyContext, req *raft_cmdpb.AdminReques
 func (a *applier) execComputeHash(aCtx *applyContext, req *raft_cmdpb.AdminRequest) (
 	resp *raft_cmdpb.AdminResponse, result applyResult, err error) {
 	resp = new(raft_cmdpb.AdminResponse)
-	result = applyResult{tp: applyResultTypeExecResult, data: &execResultComputeHash{
-		region: a.region,
-		index:  aCtx.execCtx.index,
-		// This snapshot may be held for a long time, which may cause too many
-		// open files in rocksdb.
-		// TODO: figure out another way to do consistency check without snapshot
-		// or short life snapshot.
-		snap: mvcc.NewDBSnapshot(aCtx.engines.kv),
-	}}
+	// TODO: run in goroutine.
 	return
 }
 

--- a/tikv/raftstore/engine.go
+++ b/tikv/raftstore/engine.go
@@ -95,6 +95,11 @@ func (en *Engines) newRegionSnapshot(regionId, redoIdx uint64) (snap *regionSnap
 	}
 
 	txn := en.kv.DB.NewTransaction(false)
+	defer func() {
+		if err != nil {
+			txn.Discard()
+		}
+	}()
 
 	// Verify that the region version to make sure the start key and end key has not changed.
 	regionState := new(raft_serverpb.RegionLocalState)

--- a/tikv/raftstore/peer_storage.go
+++ b/tikv/raftstore/peer_storage.go
@@ -1082,6 +1082,7 @@ func doSnapshot(engines *Engines, mgr *SnapManager, regionId, redoIdx uint64) (*
 	if err != nil {
 		return nil, err
 	}
+	defer snap.txn.Discard()
 	if snap.regionState.GetState() != rspb.PeerState_Normal {
 		return nil, storageError(fmt.Sprintf("snap job %d seems stale, skip", regionId))
 	}

--- a/tikv/write.go
+++ b/tikv/write.go
@@ -377,6 +377,7 @@ func (writer *dbWriter) DeleteRange(startKey, endKey []byte, latchHandle mvcc.La
 	oldStartKey := mvcc.EncodeOldKey(startKey, maxSystemTS)
 	oldEndKey := mvcc.EncodeOldKey(endKey, maxSystemTS)
 	txn := writer.bundle.DB.NewTransaction(false)
+	defer txn.Discard()
 	reader := dbreader.NewDBReader(startKey, endKey, txn, atomic.LoadUint64(&writer.safePoint.timestamp))
 	keys = writer.collectRangeKeys(reader.GetIter(), startKey, endKey, keys)
 	keys = writer.collectRangeKeys(reader.GetIter(), oldStartKey, oldEndKey, keys)


### PR DESCRIPTION
Some transaction in raftstore code is never discarded

- discard the transactions.
- simplify the ReadExecutor because the snapshot it's never used.