### PR TITLE
fix pessimistic lock return values

### DIFF
--- a/tikv/mvcc.go
+++ b/tikv/mvcc.go
@@ -416,7 +416,7 @@ func (store *MVCCStore) handleCheckPessimisticErr(startTS uint64, err error, isF
 	if lock, ok := err.(*ErrLocked); ok {
 		keyHash := farm.Fingerprint64(lock.Key)
 		waitTimeDuration := store.normalizeWaitTime(lockWaitTime)
-		log.Infof("%d blocked by %d on key %d", startTS, lock.StartTS, keyHash)
+		log.Debugf("%d blocked by %d on key %d", startTS, lock.StartTS, keyHash)
 		waiter := store.lockWaiterManager.NewWaiter(startTS, lock.StartTS, keyHash, waitTimeDuration)
 		if !isFirstLock {
 			store.DeadlockDetectCli.Detect(startTS, lock.StartTS, keyHash)

--- a/tikv/mvcc.go
+++ b/tikv/mvcc.go
@@ -223,7 +223,10 @@ func sortKeys(keys [][]byte) [][]byte {
 }
 
 func (store *MVCCStore) PessimisticLock(reqCtx *requestCtx, req *kvrpcpb.PessimisticLockRequest, resp *kvrpcpb.PessimisticLockResponse) (*lockwaiter.Waiter, error) {
-	mutations := sortMutations(req.Mutations)
+	mutations := req.Mutations
+	if !req.ReturnValues {
+		mutations = sortMutations(req.Mutations)
+	}
 	startTS := req.StartVersion
 	regCtx := reqCtx.regCtx
 	hashVals := mutationsToHashVals(mutations)

--- a/util/lockwaiter/lockwaiter.go
+++ b/util/lockwaiter/lockwaiter.go
@@ -171,7 +171,7 @@ func (lw *Manager) WakeUp(txn, commitTS uint64, keyHashes []uint64) {
 			default:
 			}
 		}
-		log.Info("wakeup", len(waiters), "txns blocked by txn", txn, " keyHashes=", keyHashes)
+		log.Debug("wakeup", len(waiters), "txns blocked by txn", txn, " keyHashes=", keyHashes)
 	}
 	// wake up delay waiters, this will not remove waiter from queue
 	if len(wakeUpDelayWaiters) > 0 {


### PR DESCRIPTION
If 'ReturnValues' is true, we should not sort the mutations.