### PR TITLE
replace badger version with transaction TS.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -54,10 +54,11 @@ type Coprocessor struct {
 }
 
 type Engine struct {
-	DBPath           string `toml:"db-path"`             // Directory to store the data in. Should exist and be writable.
-	ValueThreshold   int    `toml:"value-threshold"`     // If value size >= this threshold, only store value offsets in tree.
-	MaxMemTableSize  int64  `toml:"max-mem-table-size"`  // Each mem table is at most this size.
-	MaxTableSize     int64  `toml:"max-table-size"`      // Each table file is at most this size.
+	DBPath           string `toml:"db-path"`            // Directory to store the data in. Should exist and be writable.
+	ValueThreshold   int    `toml:"value-threshold"`    // If value size >= this threshold, only store value offsets in tree.
+	MaxMemTableSize  int64  `toml:"max-mem-table-size"` // Each mem table is at most this size.
+	MaxTableSize     int64  `toml:"max-table-size"`     // Each table file is at most this size.
+	L1Size           int64  `toml:"l1-size"`
 	NumMemTables     int    `toml:"num-mem-tables"`      // Maximum number of tables to keep in memory, before stalling.
 	NumL0Tables      int    `toml:"num-L0-tables"`       // Maximum number of Level 0 tables before we start compacting.
 	NumL0TablesStall int    `toml:"num-L0-tables-stall"` // Maximum number of Level 0 tables before stalling.
@@ -70,6 +71,8 @@ type Engine struct {
 	BlockCacheSize    int64    `toml:"block-cache-size"`
 	Compression       []string `toml:"compression"` // Compression types for each level
 	IngestCompression string   `toml:"ingest-compression"`
+
+	CompactL0WhenClose bool `toml:"compact-l0-when-close"`
 }
 
 type PessimisticTxn struct {
@@ -114,18 +117,20 @@ var DefaultConf = Config{
 		CustomRaftLog:            true,
 	},
 	Engine: Engine{
-		DBPath:           "/tmp/badger",
-		ValueThreshold:   256,
-		MaxMemTableSize:  64 * MB,
-		MaxTableSize:     8 * MB,
-		NumMemTables:     3,
-		NumL0Tables:      4,
-		NumL0TablesStall: 8,
-		VlogFileSize:     256 * MB,
-		NumCompactors:    3,
-		SurfStartLevel:   8,
-		Compression:      make([]string, 7),
-		BlockCacheSize:   0, // 0 means disable block cache, use mmap to access sst.
+		DBPath:             "/tmp/badger",
+		ValueThreshold:     256,
+		MaxMemTableSize:    64 * MB,
+		MaxTableSize:       8 * MB,
+		NumMemTables:       3,
+		NumL0Tables:        4,
+		NumL0TablesStall:   8,
+		VlogFileSize:       256 * MB,
+		NumCompactors:      3,
+		SurfStartLevel:     8,
+		L1Size:             512 * MB,
+		Compression:        make([]string, 7),
+		BlockCacheSize:     0, // 0 means disable block cache, use mmap to access sst.
+		CompactL0WhenClose: true,
 	},
 	Coprocessor: Coprocessor{
 		RegionMaxKeys:   1440000,

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ngaut/unistore
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/coocood/badger v1.5.1-0.20200320132105-d0ba060fb5dd
+	github.com/coocood/badger v1.5.1-0.20200331023742-14df303ca911
 	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2
 	github.com/golang/protobuf v1.3.4

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ngaut/unistore
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/coocood/badger v1.5.1-0.20200224033957-264a46414d6d
+	github.com/coocood/badger v1.5.1-0.20200320132105-d0ba060fb5dd
 	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2
 	github.com/golang/protobuf v1.3.4

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/coocood/badger v1.5.1-0.20200320132105-d0ba060fb5dd h1:gyrCwshr2T4PcfQrj2d2ygWixhd6glJAmKnTYpo4ANs=
 github.com/coocood/badger v1.5.1-0.20200320132105-d0ba060fb5dd/go.mod h1:9undH6RrUSFAWSfu0ZsVYcWpkmqTzYatPF6X696aro4=
+github.com/coocood/badger v1.5.1-0.20200331023742-14df303ca911 h1:I5rt4fbvbhFo2GjYI25AIrP5j3ZdJ8sb+5OxItf20Ak=
+github.com/coocood/badger v1.5.1-0.20200331023742-14df303ca911/go.mod h1:9undH6RrUSFAWSfu0ZsVYcWpkmqTzYatPF6X696aro4=
 github.com/coocood/bbloom v0.0.0-20190830030839-58deb6228d64 h1:W1SHiII3e0jVwvaQFglwu3kS9NLxOeTpvik7MbKCyuQ=
 github.com/coocood/bbloom v0.0.0-20190830030839-58deb6228d64/go.mod h1:F86k/6c7aDUdwSUevnLpHS/3Q9hzYCE99jGk2xsHnt0=
 github.com/coocood/rtutil v0.0.0-20190304133409-c84515f646f2 h1:NnLfQ77q0G4k2Of2c1ceQ0ec6MkLQyDp+IGdVM0D8XM=

--- a/go.sum
+++ b/go.sum
@@ -27,12 +27,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/coocood/badger v1.5.1-0.20200207120029-8afdbaf63a55 h1:eiv7iKGZLNOkqSbgFMoMBf1B3fKRJwPGBkMjMmDYZIQ=
-github.com/coocood/badger v1.5.1-0.20200207120029-8afdbaf63a55/go.mod h1:aV+ApCzr5P9xzF8ZeLYCmrzeuFnDErIBEqds1tSdo1g=
-github.com/coocood/badger v1.5.1-0.20200220035627-7357f3bde3ad h1:aXp2uGyjMMbEr3148EEZ2Tls2qRIcNVg6puB13h6vwQ=
-github.com/coocood/badger v1.5.1-0.20200220035627-7357f3bde3ad/go.mod h1:aV+ApCzr5P9xzF8ZeLYCmrzeuFnDErIBEqds1tSdo1g=
-github.com/coocood/badger v1.5.1-0.20200224033957-264a46414d6d h1:cTTjum7YgS3vZJBP15V6gDayejMeEvYOX98SWDsD9Qs=
-github.com/coocood/badger v1.5.1-0.20200224033957-264a46414d6d/go.mod h1:aV+ApCzr5P9xzF8ZeLYCmrzeuFnDErIBEqds1tSdo1g=
+github.com/coocood/badger v1.5.1-0.20200320132105-d0ba060fb5dd h1:gyrCwshr2T4PcfQrj2d2ygWixhd6glJAmKnTYpo4ANs=
+github.com/coocood/badger v1.5.1-0.20200320132105-d0ba060fb5dd/go.mod h1:9undH6RrUSFAWSfu0ZsVYcWpkmqTzYatPF6X696aro4=
 github.com/coocood/bbloom v0.0.0-20190830030839-58deb6228d64 h1:W1SHiII3e0jVwvaQFglwu3kS9NLxOeTpvik7MbKCyuQ=
 github.com/coocood/bbloom v0.0.0-20190830030839-58deb6228d64/go.mod h1:F86k/6c7aDUdwSUevnLpHS/3Q9hzYCE99jGk2xsHnt0=
 github.com/coocood/rtutil v0.0.0-20190304133409-c84515f646f2 h1:NnLfQ77q0G4k2Of2c1ceQ0ec6MkLQyDp+IGdVM0D8XM=

--- a/tikv/dbreader/db_reader.go
+++ b/tikv/dbreader/db_reader.go
@@ -37,12 +37,11 @@ import (
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 )
 
-func NewDBReader(startKey, endKey []byte, txn *badger.Txn, safePoint uint64) *DBReader {
+func NewDBReader(startKey, endKey []byte, txn *badger.Txn) *DBReader {
 	return &DBReader{
-		startKey:  startKey,
-		endKey:    endKey,
-		txn:       txn,
-		safePoint: safePoint,
+		startKey: startKey,
+		endKey:   endKey,
+		txn:      txn,
 	}
 }
 
@@ -60,12 +59,11 @@ func NewIterator(txn *badger.Txn, reverse bool, startKey, endKey []byte) *badger
 
 // DBReader reads data from DB, for read-only requests, the locks must already be checked before DBReader is created.
 type DBReader struct {
-	startKey  []byte
-	endKey    []byte
-	txn       *badger.Txn
-	iter      *badger.Iterator
-	revIter   *badger.Iterator
-	safePoint uint64
+	startKey []byte
+	endKey   []byte
+	txn      *badger.Txn
+	iter     *badger.Iterator
+	revIter  *badger.Iterator
 }
 
 // GetMvccInfoByKey fills MvccInfo reading committed keys from db

--- a/tikv/mvcc.go
+++ b/tikv/mvcc.go
@@ -1124,7 +1124,7 @@ type GCCompactionFilter struct {
 // Filter implements the badger.CompactionFilter interface.
 // Since we use txn ts as badger version, we do not need to filter anything.
 func (f *GCCompactionFilter) Filter(key, value, userMeta []byte) badger.Decision {
-	return badger.DecisionKeep
+	return badger.DecisionDrop
 }
 
 var (

--- a/tikv/mvcc.go
+++ b/tikv/mvcc.go
@@ -767,8 +767,8 @@ func (store *MVCCStore) handleLockNotFound(reqCtx *requestCtx, key []byte, start
 	if item == nil {
 		return ErrLockNotFound
 	}
-	useMeta := mvcc.DBUserMeta(item.UserMeta())
-	if useMeta.StartTS() == startTS {
+	userMeta := mvcc.DBUserMeta(item.UserMeta())
+	if userMeta.StartTS() == startTS {
 		// Already committed.
 		return nil
 	}

--- a/tikv/mvcc.go
+++ b/tikv/mvcc.go
@@ -61,14 +61,14 @@ type MVCCStore struct {
 }
 
 // NewMVCCStore creates a new MVCCStore
-func NewMVCCStore(bundle *mvcc.DBBundle, safePoint *SafePoint, dataDir string,
+func NewMVCCStore(bundle *mvcc.DBBundle, dataDir string, safePoint *SafePoint,
 	writer mvcc.DBWriter, pdClinet pd.Client) *MVCCStore {
 	store := &MVCCStore{
 		db:                bundle.DB,
 		dir:               dataDir,
 		lockStore:         bundle.LockStore,
-		dbWriter:          writer,
 		safePoint:         safePoint,
+		dbWriter:          writer,
 		lockWaiterManager: lockwaiter.NewManager(),
 	}
 	store.DeadlockDetectSvr = NewDetectorServer()

--- a/tikv/mvcc.go
+++ b/tikv/mvcc.go
@@ -21,7 +21,6 @@ import (
 	"math"
 	"os"
 	"sort"
-	"sync"
 	"sync/atomic"
 	"time"
 	"unsafe"
@@ -51,8 +50,6 @@ type MVCCStore struct {
 	lockStore *lockstore.MemStore
 	dbWriter  mvcc.DBWriter
 	safePoint *SafePoint
-
-	gcLock sync.Mutex
 
 	latestTS          uint64
 	lockWaiterManager *lockwaiter.Manager
@@ -1190,7 +1187,7 @@ const (
 )
 
 // Filter implements the badger.CompactionFilter interface.
-// Since we use txn ts as badger version, we do not need to filter anything.
+// Since we use txn ts as badger version, we only need to filter Delete, Rollback and Op_Lock.
 // It is called for the first valid version before safe point, older versions are discarded automatically.
 func (f *GCCompactionFilter) Filter(key, value, userMeta []byte) badger.Decision {
 	switch key[0] {

--- a/tikv/mvcc/db_writer.go
+++ b/tikv/mvcc/db_writer.go
@@ -44,22 +44,19 @@ type WriteBatch interface {
 }
 
 type DBBundle struct {
-	DB            *badger.DB
-	LockStore     *lockstore.MemStore
-	RollbackStore *lockstore.MemStore
-	MemStoreMu    sync.Mutex
+	DB         *badger.DB
+	LockStore  *lockstore.MemStore
+	MemStoreMu sync.Mutex
 }
 
 type DBSnapshot struct {
-	Txn           *badger.Txn
-	LockStore     *lockstore.MemStore
-	RollbackStore *lockstore.MemStore
+	Txn       *badger.Txn
+	LockStore *lockstore.MemStore
 }
 
 func NewDBSnapshot(db *DBBundle) *DBSnapshot {
 	return &DBSnapshot{
-		Txn:           db.DB.NewTransaction(false),
-		LockStore:     db.LockStore,
-		RollbackStore: db.RollbackStore,
+		Txn:       db.DB.NewTransaction(false),
+		LockStore: db.LockStore,
 	}
 }

--- a/tikv/mvcc_test.go
+++ b/tikv/mvcc_test.go
@@ -89,7 +89,6 @@ func NewTestStore(dbPrefix string, logPrefix string, c *C) (*TestStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	safePoint := &SafePoint{}
 	db, err := CreateTestDB(dbPath, LogPath)
 	if err != nil {
 		return nil, err
@@ -110,7 +109,7 @@ func NewTestStore(dbPrefix string, logPrefix string, c *C) (*TestStore, error) {
 	engines := raftstore.NewEngines(dbBundle, dbBundle.DB, kvPath, raftPath)
 	writer := raftstore.NewTestRaftWriter(dbBundle, engines)
 
-	store := NewMVCCStore(dbBundle, dbPath, safePoint, writer, nil)
+	store := NewMVCCStore(dbBundle, dbPath, writer, nil)
 	svr := NewServer(nil, store, nil)
 	return &TestStore{
 		MvccStore: store,
@@ -1112,6 +1111,7 @@ func (s *testMvccSuite) TestMinCommitTs(c *C) {
 }
 
 func (s *testMvccSuite) TestGC(c *C) {
+	c.Skip("GC work is hand over to badger.")
 	store, err := NewTestStore("TestGC", "TestGC", c)
 	c.Assert(err, IsNil)
 	defer CleanTestStore(store)

--- a/tikv/mvcc_test.go
+++ b/tikv/mvcc_test.go
@@ -89,6 +89,7 @@ func NewTestStore(dbPrefix string, logPrefix string, c *C) (*TestStore, error) {
 	if err != nil {
 		return nil, err
 	}
+	safePoint := &SafePoint{}
 	db, err := CreateTestDB(dbPath, LogPath)
 	if err != nil {
 		return nil, err
@@ -108,7 +109,7 @@ func NewTestStore(dbPrefix string, logPrefix string, c *C) (*TestStore, error) {
 	engines := raftstore.NewEngines(dbBundle, dbBundle.DB, kvPath, raftPath)
 	writer := raftstore.NewTestRaftWriter(dbBundle, engines)
 
-	store := NewMVCCStore(dbBundle, dbPath, writer, nil)
+	store := NewMVCCStore(dbBundle, safePoint, dbPath, writer, nil)
 	svr := NewServer(nil, store, nil)
 	return &TestStore{
 		MvccStore: store,

--- a/tikv/mvcc_test.go
+++ b/tikv/mvcc_test.go
@@ -109,7 +109,7 @@ func NewTestStore(dbPrefix string, logPrefix string, c *C) (*TestStore, error) {
 	engines := raftstore.NewEngines(dbBundle, dbBundle.DB, kvPath, raftPath)
 	writer := raftstore.NewTestRaftWriter(dbBundle, engines)
 
-	store := NewMVCCStore(dbBundle, safePoint, dbPath, writer, nil)
+	store := NewMVCCStore(dbBundle, dbPath, safePoint, writer, nil)
 	svr := NewServer(nil, store, nil)
 	return &TestStore{
 		MvccStore: store,

--- a/tikv/raftstore/applier.go
+++ b/tikv/raftstore/applier.go
@@ -947,8 +947,8 @@ func (a *applier) execCustomLog(actx *applyContext, cl *raftlog.CustomRaftLog) (
 			cnt++
 		})
 	case raftlog.TypeRolback:
-		cl.IterateRollback(func(key []byte, deleteLock bool) {
-			actx.wb.Rollback(key)
+		cl.IterateRollback(func(key []byte, startTS uint64, deleteLock bool) {
+			actx.wb.Rollback(y.KeyWithTs(key, startTS))
 			if deleteLock {
 				actx.wb.DeleteLock(key[:len(key)-8])
 			}
@@ -1158,7 +1158,7 @@ func (a *applier) execRollback(aCtx *applyContext, op rollbackOp) {
 		if err != nil {
 			panic(op.putWrite.Key)
 		}
-		aCtx.wb.Rollback(append(rawKey, remain...))
+		aCtx.wb.Rollback(y.KeyWithTs(rawKey, mvcc.DecodeKeyTS(remain)))
 		if op.delLock != nil {
 			aCtx.wb.DeleteLock(rawKey)
 		}

--- a/tikv/raftstore/applier.go
+++ b/tikv/raftstore/applier.go
@@ -639,7 +639,8 @@ func (a *applier) updateMetrics(aCtx *applyContext) {
 }
 
 func (a *applier) writeApplyState(wb *WriteBatch) {
-	wb.Set(ApplyStateKey(a.region.Id), a.applyState.Marshal())
+	applyStateKey := y.KeyWithTs(ApplyStateKey(a.region.Id), KvTS)
+	wb.Set(applyStateKey, a.applyState.Marshal())
 }
 
 func (a *applier) handleRaftEntryNormal(aCtx *applyContext, entry *eraftpb.Entry) applyResult {
@@ -1101,15 +1102,6 @@ func convertPrewriteToLock(op prewriteOp, txn *badger.Txn) (key, value []byte) {
 	if err != nil {
 		panic(op.putLock.Value)
 	}
-	if item, err := txn.Get(rawKey); err == nil {
-		val, err1 := item.Value()
-		if err1 != nil {
-			panic(err1)
-		}
-		lock.HasOldVer = true
-		lock.OldMeta = item.UserMeta()
-		lock.OldVal = val
-	}
 	if op.putDefault != nil {
 		lock.Value = op.putDefault.Value
 	}
@@ -1136,28 +1128,10 @@ func (a *applier) commitLock(aCtx *applyContext, rawKey []byte, val []byte, comm
 	var sizeDiff int64
 	userMeta := mvcc.NewDBUserMeta(lock.StartTS, commitTS)
 	if lock.Op != uint8(kvrpcpb.Op_Lock) {
-		aCtx.wb.SetWithUserMeta(rawKey, lock.Value, userMeta)
+		aCtx.wb.SetWithUserMeta(y.KeyWithTs(rawKey, commitTS), lock.Value, userMeta)
 		sizeDiff = int64(len(rawKey) + len(lock.Value))
-		if lock.HasOldVer {
-			oldKey := mvcc.EncodeOldKey(rawKey, lock.OldMeta.CommitTS())
-			aCtx.wb.SetWithUserMeta(oldKey, lock.OldVal, lock.OldMeta.ToOldUserMeta(commitTS))
-			sizeDiff -= int64(len(rawKey) + len(lock.OldVal))
-		}
 	} else if bytes.Equal(lock.Primary, rawKey) {
-		// For primary key with Op_Lock type, the value need to be skipped, but we need to keep the transaction status.
-		// So we put it as old key directly.
-		if lock.HasOldVer {
-			// There is a latest value, we don't want to move the value to the old key space for performance and simplicity.
-			// Write the lock as old key directly to store the transaction status.
-			// The old entry doesn't have value as Delete entry, but we can compare the commitTS in key and NextCommitTS
-			// in the user meta to determine if the entry is Delete or Op_Lock.
-			// If NextCommitTS equals CommitTS, it is Op_Lock, otherwise, it is Delete.
-			oldKey := mvcc.EncodeOldKey(rawKey, commitTS)
-			aCtx.wb.SetWithUserMeta(oldKey, nil, userMeta)
-		} else {
-			// Convert the lock to a delete to store the transaction status.
-			aCtx.wb.SetWithUserMeta(rawKey, nil, userMeta)
-		}
+		aCtx.wb.SetOpLock(y.KeyWithTs(rawKey, commitTS), userMeta)
 	}
 	if sizeDiff > 0 {
 		a.metrics.sizeDiffHint += uint64(sizeDiff)
@@ -1171,7 +1145,7 @@ func (a *applier) getLock(aCtx *applyContext, rawKey []byte) []byte {
 	}
 	lockEntries := aCtx.wb.lockEntries
 	for i := len(lockEntries) - 1; i >= 0; i-- {
-		if bytes.Equal(lockEntries[i].Key, rawKey) {
+		if bytes.Equal(lockEntries[i].Key.UserKey, rawKey) {
 			return lockEntries[i].Value
 		}
 	}
@@ -1215,18 +1189,7 @@ func (a *applier) execDeleteRange(aCtx *applyContext, req *raft_cmdpb.DeleteRang
 		if bytes.Compare(item.Key(), endKey) >= 0 {
 			break
 		}
-		aCtx.wb.Delete(item.KeyCopy(nil))
-	}
-	it.Close()
-	oldStartKey := mvcc.EncodeOldKey(startKey, 0)
-	oldEndKey := mvcc.EncodeOldKey(endKey, 0)
-	it = dbreader.NewIterator(txn, false, oldStartKey, oldEndKey)
-	for it.Seek(oldStartKey); it.Valid(); it.Next() {
-		item := it.Item()
-		if bytes.Compare(item.Key(), oldEndKey) >= 0 {
-			break
-		}
-		aCtx.wb.Delete(item.KeyCopy(nil))
+		aCtx.wb.Delete(y.KeyWithTs(item.KeyCopy(nil), item.Version()+1))
 	}
 	it.Close()
 	lockIt := aCtx.engines.kv.LockStore.NewIterator()

--- a/tikv/raftstore/db_writer.go
+++ b/tikv/raftstore/db_writer.go
@@ -315,8 +315,7 @@ func (wb *customWriteBatch) Commit(key []byte, lock *mvcc.MvccLock) {
 
 func (wb *customWriteBatch) Rollback(key []byte, deleleLock bool) {
 	wb.setType(raftlog.TypeRolback)
-	rollbackKey := mvcc.EncodeRollbackKey(nil, key, wb.startTS)
-	wb.builder.AppendRollback(rollbackKey, deleleLock)
+	wb.builder.AppendRollback(key, wb.startTS, deleleLock)
 }
 
 func (wb *customWriteBatch) PessimisticLock(key []byte, lock *mvcc.MvccLock) {

--- a/tikv/raftstore/engine.go
+++ b/tikv/raftstore/engine.go
@@ -351,7 +351,7 @@ func deleteRange(db *mvcc.DBBundle, startKey, endKey []byte) error {
 	// Delete keys first.
 	keys := make([]y.Key, 0, delRangeBatchSize)
 	txn := db.DB.NewTransaction(false)
-	reader := dbreader.NewDBReader(startKey, endKey, txn, 0)
+	reader := dbreader.NewDBReader(startKey, endKey, txn)
 	keys = collectRangeKeys(reader.GetIter(), startKey, endKey, keys)
 	reader.Close()
 	if err := deleteKeysInBatch(db, keys, delRangeBatchSize); err != nil {

--- a/tikv/raftstore/engine.go
+++ b/tikv/raftstore/engine.go
@@ -197,24 +197,24 @@ func (wb *WriteBatch) Rollback(key y.Key) {
 	})
 }
 
-func (wb *WriteBatch) SetWithUserMeta(key y.Key, val, useMeta []byte) {
+func (wb *WriteBatch) SetWithUserMeta(key y.Key, val, userMeta []byte) {
 	wb.entries = append(wb.entries, &badger.Entry{
 		Key:      key,
 		Value:    val,
-		UserMeta: useMeta,
+		UserMeta: userMeta,
 	})
-	wb.size += key.Len() + len(val) + len(useMeta)
+	wb.size += key.Len() + len(val) + len(userMeta)
 }
 
-func (wb *WriteBatch) SetOpLock(key y.Key, useMeta []byte) {
-	startTS := mvcc.DBUserMeta(useMeta).StartTS()
+func (wb *WriteBatch) SetOpLock(key y.Key, userMeta []byte) {
+	startTS := mvcc.DBUserMeta(userMeta).StartTS()
 	opLockKey := y.KeyWithTs(mvcc.EncodeExtraTxnStatusKey(key.UserKey, startTS), key.Version)
 	e := &badger.Entry{
 		Key:      opLockKey,
-		UserMeta: useMeta,
+		UserMeta: userMeta,
 	}
 	wb.entries = append(wb.entries, e)
-	wb.size += key.Len() + len(useMeta)
+	wb.size += key.Len() + len(userMeta)
 }
 
 func (wb *WriteBatch) Delete(key y.Key) {

--- a/tikv/raftstore/restore.go
+++ b/tikv/raftstore/restore.go
@@ -17,7 +17,6 @@ import (
 	"encoding/binary"
 
 	"github.com/coocood/badger"
-	"github.com/coocood/badger/y"
 	"github.com/ngaut/log"
 	"github.com/ngaut/unistore/lockstore"
 	"github.com/ngaut/unistore/tikv/mvcc"
@@ -37,11 +36,10 @@ func RestoreLockStore(offset uint64, bundle *mvcc.DBBundle, raftDB *badger.DB) e
 		if err != nil {
 			return
 		}
-		key := y.ParseKey(e.Key)
-		if !isRaftLogKey(key) {
+		if !isRaftLogKey(e.Key.UserKey) {
 			return
 		}
-		applied, err := isRaftLogApplied(key, appliedIndices, txn)
+		applied, err := isRaftLogApplied(e.Key.UserKey, appliedIndices, txn)
 		if err != nil {
 			return
 		}

--- a/tikv/raftstore/restore_test.go
+++ b/tikv/raftstore/restore_test.go
@@ -50,7 +50,6 @@ func TestRestore(t *testing.T) {
 	v1 := []byte("v")
 
 	lockStore := lockstore.NewMemStore(1000)
-	rollbackStore := lockstore.NewMemStore(1000)
 	// Restore prewrite
 	expectLock := mvcc.MvccLock{
 		MvccLockHdr: mvcc.MvccLockHdr{
@@ -64,7 +63,7 @@ func TestRestore(t *testing.T) {
 	}
 	wb.Prewrite(k1, &expectLock)
 	txn := engines.kv.DB.NewTransaction(true)
-	err := restoreAppliedEntry(genEntry(wb, t), txn, lockStore, rollbackStore)
+	err := restoreAppliedEntry(genEntry(wb, t), txn, lockStore)
 	require.Nil(t, err)
 
 	// Restore commit
@@ -74,7 +73,7 @@ func TestRestore(t *testing.T) {
 	}
 	wbCommit.Commit(k1, &expectLock)
 	txn = engines.kv.DB.NewTransaction(true)
-	err = restoreAppliedEntry(genEntry(wbCommit, t), txn, lockStore, rollbackStore)
+	err = restoreAppliedEntry(genEntry(wbCommit, t), txn, lockStore)
 	require.Nil(t, err)
 
 	// Restore common rollback
@@ -84,7 +83,7 @@ func TestRestore(t *testing.T) {
 	}
 	wbRollback.Rollback(k1, true)
 	txn = engines.kv.DB.NewTransaction(true)
-	err = restoreAppliedEntry(genEntry(wbRollback, t), txn, lockStore, rollbackStore)
+	err = restoreAppliedEntry(genEntry(wbRollback, t), txn, lockStore)
 	require.Nil(t, err)
 
 	// Restore pessimistic rollback
@@ -94,6 +93,6 @@ func TestRestore(t *testing.T) {
 	}
 	wbPessimisticRollback.PessimisticRollback(k1)
 	txn = engines.kv.DB.NewTransaction(true)
-	err = restoreAppliedEntry(genEntry(wbPessimisticRollback, t), txn, lockStore, rollbackStore)
+	err = restoreAppliedEntry(genEntry(wbPessimisticRollback, t), txn, lockStore)
 	require.Nil(t, err)
 }

--- a/tikv/raftstore/snap.go
+++ b/tikv/raftstore/snap.go
@@ -105,26 +105,23 @@ type SnapStatistics struct {
 }
 
 type ApplyOptions struct {
-	DBBundle   *mvcc.DBBundle
-	Region     *metapb.Region
-	Abort      *uint32
-	Builder    *table.Builder
-	OldBuilder *table.Builder
+	DBBundle *mvcc.DBBundle
+	Region   *metapb.Region
+	Abort    *uint32
+	Builder  *table.Builder
 }
 
-func newApplyOptions(db *mvcc.DBBundle, region *metapb.Region, abort *uint32, builder, oldBuilder *table.Builder) *ApplyOptions {
+func newApplyOptions(db *mvcc.DBBundle, region *metapb.Region, abort *uint32, builder *table.Builder) *ApplyOptions {
 	return &ApplyOptions{
-		DBBundle:   db,
-		Region:     region,
-		Abort:      abort,
-		Builder:    builder,
-		OldBuilder: oldBuilder,
+		DBBundle: db,
+		Region:   region,
+		Abort:    abort,
+		Builder:  builder,
 	}
 }
 
 type ApplyResult struct {
 	HasPut      bool
-	HasOldPut   bool
 	RegionState *rspb.RegionLocalState
 }
 
@@ -766,16 +763,10 @@ func (s *Snap) Apply(opts ApplyOptions) (ApplyResult, error) {
 				Value:    item.val,
 				UserMeta: item.userMeta,
 			})
-		case applySnapTypePutOld:
-			result.HasOldPut = true
-			opts.OldBuilder.Add(item.key, y.ValueStruct{
-				Value:    item.val,
-				UserMeta: item.userMeta,
-			})
 		case applySnapTypeLock:
-			opts.DBBundle.LockStore.Put(item.key, item.val)
+			opts.DBBundle.LockStore.Put(item.key.UserKey, item.val)
 		case applySnapTypeRollback:
-			opts.DBBundle.RollbackStore.Put(item.key, item.val)
+			opts.DBBundle.RollbackStore.Put(item.key.UserKey, item.val)
 		}
 	}
 

--- a/tikv/raftstore/snap_applier.go
+++ b/tikv/raftstore/snap_applier.go
@@ -27,7 +27,7 @@ import (
 )
 
 type applySnapItem struct {
-	key           []byte
+	key           y.Key
 	val           []byte
 	userMeta      []byte
 	applySnapType byte
@@ -35,7 +35,6 @@ type applySnapItem struct {
 
 const (
 	applySnapTypePut = iota
-	applySnapTypePutOld
 	applySnapTypeLock
 	applySnapTypeRollback
 )
@@ -121,14 +120,14 @@ func (ai *snapApplier) next() (*applySnapItem, error) {
 
 func (ai *snapApplier) nextLock() (*applySnapItem, error) {
 	item := new(applySnapItem)
-	item.key = ai.curLockKey
+	item.key = y.KeyWithTs(ai.curLockKey, 0)
 	item.applySnapType = applySnapTypeLock
 	item.userMeta = mvcc.LockUserMetaNone
 	lv, err := decodeLockCFValue(ai.curLockValue)
 	if err != nil {
 		return nil, err
 	}
-	val, err := ai.popFullValue(item.key, lv.startTS, lv.shortVal, lv.lockType)
+	val, err := ai.popFullValue(item.key.UserKey, lv.startTS, lv.shortVal, lv.lockType)
 	if err != nil {
 		return nil, err
 	}
@@ -139,10 +138,6 @@ func (ai *snapApplier) nextLock() (*applySnapItem, error) {
 	mvccLock.PrimaryLen = uint16(len(lv.primary))
 	mvccLock.Primary = lv.primary
 	mvccLock.Value = val
-	err = ai.loadOldValue(mvccLock)
-	if err != nil {
-		return nil, err
-	}
 	item.val = mvccLock.MarshalBinary()
 	if len(ai.lockCFData) > 1 {
 		ai.curLockKey, ai.curLockValue, ai.lockCFData, err = readEntryFromPlainFile(ai.lockCFData)
@@ -188,47 +183,17 @@ func (ai *snapApplier) loadFullValueOpt(key []byte, startTS uint64, shortVal []b
 	return shortVal, nil
 }
 
-func (ai *snapApplier) loadOldValue(lock *mvcc.MvccLock) error {
-	if lock.Op == byte(kvrpcpb.Op_Lock) {
-		return nil
-	}
-	for bytes.Equal(ai.curLockKey, ai.curWriteKey) {
-		var err error
-		writeVal := decodeWriteCFValue(y.SafeCopy(nil, ai.writeCFIterator.Value()))
-		if writeVal.writeType == byte(kvrpcpb.Op_Rollback) {
-			// Skip rollback entry, find the next write key.
-			// As long as there is a lock, it is safe to ignore the rollback keys.
-			err = ai.writeCFIteratorNext()
-			if err != nil {
-				return err
-			}
-			continue
-		}
-		lock.HasOldVer = true
-		lock.OldMeta = mvcc.NewDBUserMeta(writeVal.startTS, ai.curWriteCommitTS)
-		lock.OldVal, err = ai.loadFullValue(ai.curLockKey, writeVal.startTS, writeVal.shortValue, writeVal.writeType)
-		return err
-	}
-	return nil
-}
-
 func (ai *snapApplier) nextWrite() (*applySnapItem, error) {
 	item := new(applySnapItem)
 	writeVal := decodeWriteCFValue(y.SafeCopy(nil, ai.writeCFIterator.Value()))
 	if writeVal.writeType == byte(kvrpcpb.Op_Rollback) {
 		item.applySnapType = applySnapTypeRollback
-		item.key = codec.EncodeUintDesc(ai.curWriteKey, writeVal.startTS)
+		item.key = y.KeyWithTs(codec.EncodeUintDesc(ai.curWriteKey, writeVal.startTS), 0)
 		return item, nil
 	}
-	if bytes.Equal(ai.lastWriteKey, ai.curWriteKey) {
-		item.applySnapType = applySnapTypePutOld
-		item.key = mvcc.EncodeOldKey(ai.curWriteKey, ai.curWriteCommitTS)
-		item.userMeta = mvcc.NewDBUserMeta(writeVal.startTS, ai.curWriteCommitTS).ToOldUserMeta(ai.lastCommitTS)
-	} else {
-		item.applySnapType = applySnapTypePut
-		item.key = ai.curWriteKey
-		item.userMeta = mvcc.NewDBUserMeta(writeVal.startTS, ai.curWriteCommitTS)
-	}
+	item.applySnapType = applySnapTypePut
+	item.key = y.KeyWithTs(ai.curWriteKey, ai.curWriteCommitTS)
+	item.userMeta = mvcc.NewDBUserMeta(writeVal.startTS, ai.curWriteCommitTS)
 	val, err := ai.popFullValue(ai.curWriteKey, writeVal.startTS, writeVal.shortValue, writeVal.writeType)
 	if err != nil {
 		return nil, err

--- a/tikv/raftstore/snap_test.go
+++ b/tikv/raftstore/snap_test.go
@@ -141,11 +141,9 @@ func openDBBundle(t *testing.T, dir string) *mvcc.DBBundle {
 	db, err := badger.Open(opts)
 	require.Nil(t, err)
 	lockStore := lockstore.NewMemStore(1024)
-	rollbackStore := lockstore.NewMemStore(1024)
 	return &mvcc.DBBundle{
-		DB:            db,
-		LockStore:     lockStore,
-		RollbackStore: rollbackStore,
+		DB:        db,
+		LockStore: lockStore,
 	}
 }
 

--- a/tikv/raftstore/snap_test.go
+++ b/tikv/raftstore/snap_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/coocood/badger"
+	"github.com/coocood/badger/y"
 	"github.com/ngaut/unistore/lockstore"
 	"github.com/ngaut/unistore/tikv/mvcc"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
@@ -32,12 +33,9 @@ import (
 )
 
 var (
-	snapTestKey        = []byte("tkey")
-	snapTestKeyOld     = encodeOldKey(snapTestKey, 100)
-	regionTestBegin    = []byte("ta")
-	regionTestBeginOld = []byte("ua")
-	regionTestEnd      = []byte("tz")
-	regionTestEndOld   = []byte("uz")
+	snapTestKey     = []byte("tkey")
+	regionTestBegin = []byte("ta")
+	regionTestEnd   = []byte("tz")
 )
 
 const (
@@ -75,15 +73,10 @@ func getKVCount(t *testing.T, db *mvcc.DBBundle) int {
 	count := 0
 	err := db.DB.View(func(txn *badger.Txn) error {
 		it := txn.NewIterator(badger.DefaultIteratorOptions)
+		it.SetAllVersions(true)
 		defer it.Close()
 		for it.Seek(regionTestBegin); it.Valid(); it.Next() {
 			if bytes.Compare(it.Item().Key(), regionTestEnd) >= 0 {
-				break
-			}
-			count++
-		}
-		for it.Seek(regionTestBeginOld); it.Valid(); it.Next() {
-			if bytes.Compare(it.Item().Key(), regionTestEndOld) >= 0 {
 				break
 			}
 			count++
@@ -117,19 +110,20 @@ func genTestRegion(regionID, storeID, peerID uint64) *metapb.Region {
 }
 
 func assertEqDB(t *testing.T, expected, actual *mvcc.DBBundle) {
-	expectedVal := getDBValue(t, expected.DB, snapTestKey)
-	actualVal := getDBValue(t, actual.DB, snapTestKey)
+	expectedVal := getDBValue(t, expected.DB, snapTestKey, 200)
+	actualVal := getDBValue(t, actual.DB, snapTestKey, 200)
 	assert.Equal(t, expectedVal, actualVal)
-	expectedVal = getDBValue(t, expected.DB, snapTestKeyOld)
-	actualVal = getDBValue(t, actual.DB, snapTestKeyOld)
+	expectedVal = getDBValue(t, expected.DB, snapTestKey, 100)
+	actualVal = getDBValue(t, actual.DB, snapTestKey, 100)
 	assert.Equal(t, expectedVal, actualVal)
 	expectedLock := expected.LockStore.Get(snapTestKey, nil)
 	actualLock := actual.LockStore.Get(snapTestKey, nil)
 	assert.Equal(t, expectedLock, actualLock)
 }
 
-func getDBValue(t *testing.T, db *badger.DB, key []byte) (val []byte) {
+func getDBValue(t *testing.T, db *badger.DB, key []byte, ts uint64) (val []byte) {
 	require.Nil(t, db.View(func(txn *badger.Txn) error {
+		txn.SetReadTS(ts)
 		item, err := txn.Get(key)
 		require.Nil(t, err, string(key))
 		val, err = item.Value()
@@ -143,6 +137,7 @@ func openDBBundle(t *testing.T, dir string) *mvcc.DBBundle {
 	opts := badger.DefaultOptions
 	opts.Dir = dir
 	opts.ValueDir = dir
+	opts.ManagedTxns = true
 	db, err := badger.Open(opts)
 	require.Nil(t, err)
 	lockStore := lockstore.NewMemStore(1024)
@@ -158,12 +153,24 @@ func fillDBBundleData(t *testing.T, dbBundle *mvcc.DBBundle) {
 	// write some data.
 	// Put an new version key and an old version key.
 	err := dbBundle.DB.Update(func(txn *badger.Txn) error {
-		value := make([]byte, 32)
-		require.Nil(t, txn.SetWithMetaSlice(snapTestKey, value, mvcc.NewDBUserMeta(150, 200)))
-		oldUseMeta := mvcc.NewDBUserMeta(50, 100).ToOldUserMeta(200)
-		require.Nil(t, txn.SetWithMetaSlice(snapTestKeyOld, make([]byte, 128), oldUseMeta))
+		e := &badger.Entry{
+			Key:      y.KeyWithTs(snapTestKey, 100),
+			UserMeta: mvcc.NewDBUserMeta(50, 100),
+			Value:    make([]byte, 128),
+		}
+		require.Nil(t, txn.SetEntry(e))
 		return nil
 	})
+	err = dbBundle.DB.Update(func(txn *badger.Txn) error {
+		e := &badger.Entry{
+			Key:      y.KeyWithTs(snapTestKey, 200),
+			UserMeta: mvcc.NewDBUserMeta(150, 200),
+			Value:    make([]byte, 32),
+		}
+		require.Nil(t, txn.SetEntry(e))
+		return nil
+	})
+
 	require.Nil(t, err)
 	lockVal := &mvcc.MvccLock{
 		MvccLockHdr: mvcc.MvccLockHdr{
@@ -171,12 +178,9 @@ func fillDBBundleData(t *testing.T, dbBundle *mvcc.DBBundle) {
 			TTL:        100,
 			Op:         byte(kvrpcpb.Op_Put),
 			PrimaryLen: uint16(len(snapTestKey)),
-			HasOldVer:  true,
 		},
 		Primary: snapTestKey,
 		Value:   make([]byte, 128),
-		OldVal:  make([]byte, 32),
-		OldMeta: mvcc.NewDBUserMeta(150, 200),
 	}
 	dbBundle.LockStore.Put(snapTestKey, lockVal.MarshalBinary())
 }

--- a/tikv/raftstore/test_util_test.go
+++ b/tikv/raftstore/test_util_test.go
@@ -39,7 +39,6 @@ func newTestEngines(t *testing.T) *Engines {
 	kvOpts.ValueThreshold = 256
 	engines.kv.DB, err = badger.Open(kvOpts)
 	engines.kv.LockStore = lockstore.NewMemStore(16 * 1024)
-	engines.kv.RollbackStore = lockstore.NewMemStore(16 * 1024)
 	require.Nil(t, err)
 	engines.raftPath, err = ioutil.TempDir("", "unistore_raft")
 	require.Nil(t, err)

--- a/tikv/raftstore/test_util_test.go
+++ b/tikv/raftstore/test_util_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/coocood/badger"
 	"github.com/pingcap/kvproto/pkg/eraftpb"
-	"github.com/pingcap/tidb/util/codec"
 	"github.com/stretchr/testify/require"
 )
 
@@ -97,11 +96,4 @@ func newTestEntry(index, term uint64) eraftpb.Entry {
 		Term:  term,
 		Data:  []byte{0},
 	}
-}
-
-func encodeOldKey(key []byte, ts uint64) []byte {
-	b := append([]byte{}, key...)
-	ret := codec.EncodeUintDesc(b, ts)
-	ret[0]++
-	return ret
 }

--- a/tikv/raftstore/worker.go
+++ b/tikv/raftstore/worker.go
@@ -282,7 +282,7 @@ func (r *splitCheckHandler) handle(t task) {
 	log.Debugf("executing split check task: [regionId: %d, startKey: %s, endKey: %s]", regionId,
 		hex.EncodeToString(startKey), hex.EncodeToString(endKey))
 	txn := r.engine.NewTransaction(false)
-	reader := dbreader.NewDBReader(startKey, endKey, txn, 0)
+	reader := dbreader.NewDBReader(startKey, endKey, txn)
 	defer reader.Close()
 	var keys [][]byte
 	switch t.tp {

--- a/tikv/server.go
+++ b/tikv/server.go
@@ -108,8 +108,7 @@ func (req *requestCtx) getDBReader() *dbreader.DBReader {
 	if req.reader == nil {
 		mvccStore := req.svr.mvccStore
 		txn := mvccStore.db.NewTransaction(false)
-		safePoint := atomic.LoadUint64(&mvccStore.safePoint.timestamp)
-		req.reader = dbreader.NewDBReader(req.regCtx.startKey, req.regCtx.endKey, txn, safePoint)
+		req.reader = dbreader.NewDBReader(req.regCtx.startKey, req.regCtx.endKey, txn)
 	}
 	return req.reader
 }

--- a/tikv/util.go
+++ b/tikv/util.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/coocood/badger/y"
 	"github.com/dgryski/go-farm"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 )
@@ -69,6 +70,15 @@ func keysToHashVals(keys ...[]byte) []uint64 {
 	hashVals := make([]uint64, len(keys))
 	for i, key := range keys {
 		hashVals[i] = farm.Fingerprint64(key)
+	}
+	hashVals = sortAndDedupHashVals(hashVals)
+	return hashVals
+}
+
+func userKeysToHashVals(keys ...y.Key) []uint64 {
+	hashVals := make([]uint64, len(keys))
+	for i, key := range keys {
+		hashVals[i] = farm.Fingerprint64(key.UserKey)
 	}
 	hashVals = sortAndDedupHashVals(hashVals)
 	return hashVals

--- a/unistore-server/main.go
+++ b/unistore-server/main.go
@@ -310,6 +310,8 @@ func createDB(subPath string, safePoint *tikv.SafePoint, conf *config.Engine) *b
 	if subPath == subPathRaft {
 		// Do not need to write blob for raft engine because it will be deleted soon.
 		opts.ValueThreshold = 0
+	} else {
+		opts.ManagedTxns = true
 	}
 	opts.ValueLogWriteOptions.WriteBufferSize = 4 * 1024 * 1024
 	opts.Dir = filepath.Join(conf.DBPath, subPath)
@@ -320,7 +322,7 @@ func createDB(subPath string, safePoint *tikv.SafePoint, conf *config.Engine) *b
 	opts.NumMemtables = conf.NumMemTables
 	opts.NumLevelZeroTables = conf.NumL0Tables
 	opts.NumLevelZeroTablesStall = conf.NumL0TablesStall
-	opts.LevelOneSize = 512 * 1024 * 1024
+	opts.LevelOneSize = conf.L1Size
 	opts.SyncWrites = conf.SyncWrite
 	compressionPerLevel := make([]options.CompressionType, len(conf.Compression))
 	for i := range opts.TableBuilderOptions.CompressionPerLevel {
@@ -332,7 +334,7 @@ func createDB(subPath string, safePoint *tikv.SafePoint, conf *config.Engine) *b
 	if safePoint != nil {
 		opts.CompactionFilterFactory = safePoint.CreateCompactionFilter
 	}
-	opts.CompactL0WhenClose = false
+	opts.CompactL0WhenClose = conf.CompactL0WhenClose
 	db, err := badger.Open(opts)
 	if err != nil {
 		log.Fatal(err)

--- a/unistore-server/main.go
+++ b/unistore-server/main.go
@@ -271,7 +271,7 @@ func setupRaftInnerServer(bundle *mvcc.DBBundle, safePoint *tikv.SafePoint, pdCl
 	innerServer.Setup(pdClient)
 	router := innerServer.GetRaftstoreRouter()
 	storeMeta := innerServer.GetStoreMeta()
-	store := tikv.NewMVCCStore(bundle, safePoint, dbPath, raftstore.NewDBWriter(router), pdClient)
+	store := tikv.NewMVCCStore(bundle, dbPath, safePoint, raftstore.NewDBWriter(router), pdClient)
 	rm := tikv.NewRaftRegionManager(storeMeta, router, store.DeadlockDetectSvr)
 	innerServer.SetPeerEventObserver(rm)
 
@@ -291,7 +291,7 @@ func setupStandAlongInnerServer(bundle *mvcc.DBBundle, safePoint *tikv.SafePoint
 
 	innerServer := tikv.NewStandAlongInnerServer(bundle)
 	innerServer.Setup(pdClient)
-	store := tikv.NewMVCCStore(bundle, safePoint, conf.Engine.DBPath, tikv.NewDBWriter(bundle), pdClient)
+	store := tikv.NewMVCCStore(bundle, conf.Engine.DBPath, safePoint, tikv.NewDBWriter(bundle), pdClient)
 	store.DeadlockDetectSvr.ChangeRole(tikv.Leader)
 	rm := tikv.NewStandAloneRegionManager(bundle.DB, regionOpts, pdClient)
 

--- a/unistore-server/main.go
+++ b/unistore-server/main.go
@@ -114,10 +114,9 @@ func main() {
 	log.Info("gitHash:", gitHash)
 	log.SetLevelByString(conf.Server.LogLevel)
 	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds | log.Lshortfile)
-	safePoint := &tikv.SafePoint{}
 	log.Infof("conf %v", conf)
 	config.SetGlobalConf(conf)
-	db := createDB(subPathKV, safePoint, &conf.Engine)
+	db := createDB(subPathKV, &conf.Engine)
 	bundle := &mvcc.DBBundle{
 		DB:            db,
 		LockStore:     lockstore.NewMemStore(8 << 20),
@@ -135,9 +134,9 @@ func main() {
 		regionManager tikv.RegionManager
 	)
 	if conf.Server.Raft {
-		innerServer, store, regionManager = setupRaftInnerServer(bundle, safePoint, pdClient, conf)
+		innerServer, store, regionManager = setupRaftInnerServer(bundle, pdClient, conf)
 	} else {
-		innerServer, store, regionManager = setupStandAlongInnerServer(bundle, safePoint, pdClient, conf)
+		innerServer, store, regionManager = setupStandAlongInnerServer(bundle, pdClient, conf)
 	}
 	err = store.StartDeadlockDetection(context.Background(), pdClient, innerServer, conf.Server.Raft)
 	if err != nil {
@@ -238,7 +237,7 @@ func setupRaftStoreConf(raftConf *raftstore.Config, conf *config.Config) {
 	raftConf.SplitCheck.RegionSplitKeys = uint64(conf.Coprocessor.RegionSplitKeys)
 }
 
-func setupRaftInnerServer(bundle *mvcc.DBBundle, safePoint *tikv.SafePoint, pdClient pd.Client, conf *config.Config) (tikv.InnerServer, *tikv.MVCCStore, tikv.RegionManager) {
+func setupRaftInnerServer(bundle *mvcc.DBBundle, pdClient pd.Client, conf *config.Config) (tikv.InnerServer, *tikv.MVCCStore, tikv.RegionManager) {
 	dbPath := conf.Engine.DBPath
 	kvPath := filepath.Join(dbPath, "kv")
 	raftPath := filepath.Join(dbPath, "raft")
@@ -252,7 +251,7 @@ func setupRaftInnerServer(bundle *mvcc.DBBundle, safePoint *tikv.SafePoint, pdCl
 	raftConf.SnapPath = snapPath
 	setupRaftStoreConf(raftConf, conf)
 
-	raftDB := createDB(subPathRaft, nil, &conf.Engine)
+	raftDB := createDB(subPathRaft, &conf.Engine)
 	meta, err := bundle.LockStore.LoadFromFile(filepath.Join(kvPath, raftstore.LockstoreFileName))
 	if err != nil {
 		log.Fatal(err)
@@ -272,7 +271,7 @@ func setupRaftInnerServer(bundle *mvcc.DBBundle, safePoint *tikv.SafePoint, pdCl
 	innerServer.Setup(pdClient)
 	router := innerServer.GetRaftstoreRouter()
 	storeMeta := innerServer.GetStoreMeta()
-	store := tikv.NewMVCCStore(bundle, dbPath, safePoint, raftstore.NewDBWriter(router), pdClient)
+	store := tikv.NewMVCCStore(bundle, dbPath, raftstore.NewDBWriter(router), pdClient)
 	rm := tikv.NewRaftRegionManager(storeMeta, router, store.DeadlockDetectSvr)
 	innerServer.SetPeerEventObserver(rm)
 
@@ -283,7 +282,7 @@ func setupRaftInnerServer(bundle *mvcc.DBBundle, safePoint *tikv.SafePoint, pdCl
 	return innerServer, store, rm
 }
 
-func setupStandAlongInnerServer(bundle *mvcc.DBBundle, safePoint *tikv.SafePoint, pdClient pd.Client, conf *config.Config) (tikv.InnerServer, *tikv.MVCCStore, tikv.RegionManager) {
+func setupStandAlongInnerServer(bundle *mvcc.DBBundle, pdClient pd.Client, conf *config.Config) (tikv.InnerServer, *tikv.MVCCStore, tikv.RegionManager) {
 	regionOpts := tikv.RegionOptions{
 		StoreAddr:  conf.Server.StoreAddr,
 		PDAddr:     conf.Server.PDAddr,
@@ -292,7 +291,7 @@ func setupStandAlongInnerServer(bundle *mvcc.DBBundle, safePoint *tikv.SafePoint
 
 	innerServer := tikv.NewStandAlongInnerServer(bundle)
 	innerServer.Setup(pdClient)
-	store := tikv.NewMVCCStore(bundle, conf.Engine.DBPath, safePoint, tikv.NewDBWriter(bundle, safePoint), pdClient)
+	store := tikv.NewMVCCStore(bundle, conf.Engine.DBPath, tikv.NewDBWriter(bundle), pdClient)
 	store.DeadlockDetectSvr.ChangeRole(tikv.Leader)
 	rm := tikv.NewStandAloneRegionManager(bundle.DB, regionOpts, pdClient)
 
@@ -303,7 +302,7 @@ func setupStandAlongInnerServer(bundle *mvcc.DBBundle, safePoint *tikv.SafePoint
 	return innerServer, store, rm
 }
 
-func createDB(subPath string, safePoint *tikv.SafePoint, conf *config.Engine) *badger.DB {
+func createDB(subPath string, conf *config.Engine) *badger.DB {
 	opts := badger.DefaultOptions
 	opts.NumCompactors = conf.NumCompactors
 	opts.ValueThreshold = conf.ValueThreshold
@@ -331,9 +330,7 @@ func createDB(subPath string, safePoint *tikv.SafePoint, conf *config.Engine) *b
 	opts.TableBuilderOptions.CompressionPerLevel = compressionPerLevel
 	opts.MaxCacheSize = conf.BlockCacheSize
 	opts.TableBuilderOptions.SuRFStartLevel = conf.SurfStartLevel
-	if safePoint != nil {
-		opts.CompactionFilterFactory = safePoint.CreateCompactionFilter
-	}
+	opts.CompactionFilterFactory = tikv.CreateCompactionFilter
 	opts.CompactL0WhenClose = conf.CompactL0WhenClose
 	db, err := badger.Open(opts)
 	if err != nil {


### PR DESCRIPTION
- eliminate the extra write cost caused by move old version data to another key.
- Simplify the older version data management logic.