### PR TITLE
fix Rollback doesn’t delete the lock

### DIFF
--- a/tikv/mvcc.go
+++ b/tikv/mvcc.go
@@ -1056,6 +1056,9 @@ func (store *MVCCStore) ResolveLock(reqCtx *requestCtx, keys [][]byte, startTS, 
 			// The lock is changed, ignore it.
 			continue
 		}
+		if len(buf) == 0 {
+			continue
+		}
 		if commitTS > 0 {
 			lock := mvcc.DecodeLock(buf)
 			tmpDiff += len(lockKey) + len(lock.Value)

--- a/tikv/raftstore/applier.go
+++ b/tikv/raftstore/applier.go
@@ -950,7 +950,7 @@ func (a *applier) execCustomLog(actx *applyContext, cl *raftlog.CustomRaftLog) (
 		cl.IterateRollback(func(key []byte, startTS uint64, deleteLock bool) {
 			actx.wb.Rollback(y.KeyWithTs(key, startTS))
 			if deleteLock {
-				actx.wb.DeleteLock(key[:len(key)-8])
+				actx.wb.DeleteLock(key)
 			}
 			cnt++
 		})


### PR DESCRIPTION
- CustomLog rollback deletes a UserKey should not trim last 8 bytes.
- ScanLock should respect the limit parameter.
- ResolveLock can take given keys to avoid Scan.
- Modify the test to use CustomLog to cover the case.