### PR TITLE
fix analyze CMSketch

### DIFF
--- a/tikv/analyze.go
+++ b/tikv/analyze.go
@@ -124,14 +124,14 @@ func (p *analyzeIndexProcessor) Process(key, value []byte) error {
 	p.rowBuf = p.rowBuf[:0]
 	for _, val := range values {
 		p.rowBuf = append(p.rowBuf, val...)
+		if p.cms != nil {
+			p.cms.InsertBytes(p.rowBuf)
+		}
 	}
 	rowData := safeCopy(p.rowBuf)
 	err = p.statsBuilder.Iterate(types.NewBytesDatum(rowData))
 	if err != nil {
 		return err
-	}
-	if p.cms != nil {
-		p.cms.InsertBytes(rowData)
 	}
 	return nil
 }


### PR DESCRIPTION
A multi-column index should insert on every prefix of row values instead of full index.