### PR TITLE
fix apply state read stale value

### DIFF
--- a/tikv/mvcc/db_writer.go
+++ b/tikv/mvcc/db_writer.go
@@ -47,6 +47,7 @@ type DBBundle struct {
 	DB         *badger.DB
 	LockStore  *lockstore.MemStore
 	MemStoreMu sync.Mutex
+	StateTS    uint64
 }
 
 type DBSnapshot struct {

--- a/unistore-server/main.go
+++ b/unistore-server/main.go
@@ -127,7 +127,11 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
+	ts, err := pdClient.GetTS(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+	bundle.StateTS = ts
 	var (
 		innerServer   tikv.InnerServer
 		store         *tikv.MVCCStore


### PR DESCRIPTION
When using managed DB, we write apply state key the same version many times, it is possible that an old value is returned because it has the same version.

The solution is that we get a TS from PD at start time, put it in DBBundle, when writing to KV DB, modify the version if its version is 1.