### PR TITLE
use global latch instead of one in a region

### DIFF
--- a/tikv/mvcc_test.go
+++ b/tikv/mvcc_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/coocood/badger"
 	"github.com/coocood/badger/y"
@@ -56,7 +55,7 @@ func (ts *TestStore) newReqCtx() *requestCtx {
 func (ts *TestStore) newReqCtxWithKeys(startKey, endKey []byte) *requestCtx {
 	return &requestCtx{
 		regCtx: &regionCtx{
-			latches:  new(sync.Map),
+			latches:  newLatches(),
 			startKey: startKey,
 			endKey:   endKey,
 		},
@@ -1367,7 +1366,9 @@ func (s *testMvccSuite) TestResolveCommit(c *C) {
 	// Resolve secondary key
 	MustCommit(pk, 1, 2, store)
 	err = store.MvccStore.ResolveLock(store.newReqCtx(), [][]byte{sk}, 2, 3)
-	c.Assert(err, NotNil)
+	c.Assert(err, IsNil)
+	skLock := store.MvccStore.getLock(store.newReqCtx(), sk)
+	c.Assert(skLock, NotNil)
 	err = store.MvccStore.ResolveLock(store.newReqCtx(), [][]byte{sk}, 1, 2)
 	c.Assert(err, IsNil)
 

--- a/tikv/server.go
+++ b/tikv/server.go
@@ -118,9 +118,6 @@ func (req *requestCtx) finish() {
 	if req.reader != nil {
 		req.reader.Close()
 	}
-	if req.regCtx != nil {
-		req.regCtx.refCount.Done()
-	}
 }
 
 func (svr *Server) KvGet(ctx context.Context, req *kvrpcpb.GetRequest) (*kvrpcpb.GetResponse, error) {


### PR DESCRIPTION
Fixes https://github.com/ngaut/unistore/issues/368

So we don’t need to maintain refCount and wait for the parent region to finish.