### PR TITLE
fix bug caused by item.Value without copy

### DIFF
--- a/tikv/mvcc.go
+++ b/tikv/mvcc.go
@@ -263,7 +263,7 @@ func (store *MVCCStore) PessimisticLock(reqCtx *requestCtx, req *kvrpcpb.Pessimi
 	}
 	if req.Force {
 		dbMeta := mvcc.DBUserMeta(items[0].UserMeta())
-		val, err1 := items[0].Value()
+		val, err1 := items[0].ValueCopy(nil)
 		if err1 != nil {
 			return nil, err1
 		}
@@ -276,7 +276,7 @@ func (store *MVCCStore) PessimisticLock(reqCtx *requestCtx, req *kvrpcpb.Pessimi
 				resp.Values = append(resp.Values, nil)
 				continue
 			}
-			val, err1 := item.Value()
+			val, err1 := item.ValueCopy(nil)
 			if err1 != nil {
 				return nil, err1
 			}

--- a/tikv/raftstore/peer_storage.go
+++ b/tikv/raftstore/peer_storage.go
@@ -352,7 +352,7 @@ func getValue(engine *badger.DB, key []byte) ([]byte, error) {
 		if err != nil {
 			return err
 		}
-		val, err := item.Value()
+		val, err := item.ValueCopy(nil)
 		result = val
 		return err
 	})


### PR DESCRIPTION
When blob is enabled, the Value returns a reference to a cache memory, that cache can be rewritten on the next Value call.