### PR TITLE
fix bootstrap failed to delete prepareBootstrapKey

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ngaut/unistore
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/coocood/badger v1.5.1-0.20200415040602-9ce9ab7cc152
+	github.com/coocood/badger v1.5.1-0.20200416022742-7ec37e0c6b9a
 	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2
 	github.com/golang/protobuf v1.3.4

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/coocood/badger v1.5.1-0.20200404092445-b9bd4dd9c9e1 h1:yqdUsX1cp4YeQK
 github.com/coocood/badger v1.5.1-0.20200404092445-b9bd4dd9c9e1/go.mod h1:9undH6RrUSFAWSfu0ZsVYcWpkmqTzYatPF6X696aro4=
 github.com/coocood/badger v1.5.1-0.20200415040602-9ce9ab7cc152 h1:icLU+GRScZLj2o+lGBrMXdkO16JnD7XScx2F7bR3HtA=
 github.com/coocood/badger v1.5.1-0.20200415040602-9ce9ab7cc152/go.mod h1:9undH6RrUSFAWSfu0ZsVYcWpkmqTzYatPF6X696aro4=
+github.com/coocood/badger v1.5.1-0.20200416022742-7ec37e0c6b9a h1:RBg9qee300+trcu1uxihZ6BzB3EfqEtWAAzpFb6M0ZE=
+github.com/coocood/badger v1.5.1-0.20200416022742-7ec37e0c6b9a/go.mod h1:9undH6RrUSFAWSfu0ZsVYcWpkmqTzYatPF6X696aro4=
 github.com/coocood/bbloom v0.0.0-20190830030839-58deb6228d64 h1:W1SHiII3e0jVwvaQFglwu3kS9NLxOeTpvik7MbKCyuQ=
 github.com/coocood/bbloom v0.0.0-20190830030839-58deb6228d64/go.mod h1:F86k/6c7aDUdwSUevnLpHS/3Q9hzYCE99jGk2xsHnt0=
 github.com/coocood/rtutil v0.0.0-20190304133409-c84515f646f2 h1:NnLfQ77q0G4k2Of2c1ceQ0ec6MkLQyDp+IGdVM0D8XM=

--- a/tikv/raftstore/snap_test.go
+++ b/tikv/raftstore/snap_test.go
@@ -58,13 +58,14 @@ func getTestDBForRegions(t *testing.T, path string, regions []uint64) *mvcc.DBBu
 			appliedIndex:   10,
 			truncatedIndex: 10,
 		}
-		require.Nil(t, putValue(kv.DB, ApplyStateKey(regionID), applyState.Marshal()))
-
+		wb := new(WriteBatch)
+		wb.Set(y.KeyWithTs(ApplyStateKey(regionID), KvTS), applyState.Marshal())
 		// Put region ifno into kv engine.
 		region := genTestRegion(regionID, 1, 1)
 		regionState := new(rspb.RegionLocalState)
 		regionState.Region = region
-		require.Nil(t, putMsg(kv.DB, RegionStateKey(regionID), regionState))
+		require.Nil(t, wb.SetMsg(y.KeyWithTs(RegionStateKey(regionID), KvTS), regionState))
+		require.Nil(t, wb.WriteToKV(kv))
 	}
 	return kv
 }


### PR DESCRIPTION
Fixes https://github.com/ngaut/unistore/issues/377

The KvTS is not rewritten to DBBundle.StateTS if we use DB.Update directly,
So Delete does not take effect, then another restart will see prepareBootstrapKey,
And then delete the first region.