### PR TITLE
update badger to skip old version and fix test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ngaut/unistore
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/coocood/badger v1.5.1-0.20200526054436-226126a77c16
+	github.com/coocood/badger v1.5.1-0.20200528065104-c02ac3616d04
 	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2
 	github.com/gogo/protobuf v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/coocood/badger v1.5.1-0.20200526054436-226126a77c16 h1:FyDJfX303An2G3feUywVX5GcpXHEjK7xGTIp553oMzY=
-github.com/coocood/badger v1.5.1-0.20200526054436-226126a77c16/go.mod h1:klY8SfH2lNZ/23/SIxwHoJw+T6wYGB12YPCF9MUoiu0=
+github.com/coocood/badger v1.5.1-0.20200528065104-c02ac3616d04 h1:prWWMbnhC2+Iw/dWM0imCzaU2xjaIMQZS9V+BZ1DoUE=
+github.com/coocood/badger v1.5.1-0.20200528065104-c02ac3616d04/go.mod h1:klY8SfH2lNZ/23/SIxwHoJw+T6wYGB12YPCF9MUoiu0=
 github.com/coocood/bbloom v0.0.0-20190830030839-58deb6228d64 h1:W1SHiII3e0jVwvaQFglwu3kS9NLxOeTpvik7MbKCyuQ=
 github.com/coocood/bbloom v0.0.0-20190830030839-58deb6228d64/go.mod h1:F86k/6c7aDUdwSUevnLpHS/3Q9hzYCE99jGk2xsHnt0=
 github.com/coocood/rtutil v0.0.0-20190304133409-c84515f646f2 h1:NnLfQ77q0G4k2Of2c1ceQ0ec6MkLQyDp+IGdVM0D8XM=

--- a/tikv/mvcc_test.go
+++ b/tikv/mvcc_test.go
@@ -1387,16 +1387,16 @@ func (s *testMvccSuite) TestResolveCommit(c *C) {
 	// The error path
 	kvTxn := store.MvccStore.db.NewTransaction(true)
 	e := &badger.Entry{
-		Key: y.KeyWithTs(sk, 2),
+		Key: y.KeyWithTs(sk, 3),
 	}
 	e.SetDelete()
 	err = kvTxn.SetEntry(e)
 	c.Assert(err, IsNil)
 	err = kvTxn.Commit()
 	c.Assert(err, IsNil)
-	MustCommitErr(sk, 1, 2, store)
+	MustCommitErr(sk, 1, 3, store)
 	MustAcquirePessimisticLock(sk, sk, 5, 5, store)
-	MustCommitErr(sk, 1, 2, store)
+	MustCommitErr(sk, 1, 3, store)
 }
 
 func MustLoad(startTS, commitTS uint64, store *TestStore, pairs ...string) {


### PR DESCRIPTION
Fixes https://github.com/ngaut/unistore/issues/383

1 table with 10million rows of sysbench table.
After 10 minutes of update-non-index, the count time reduced from 2s to 1.1s。

