### PR TITLE
txn: implement some async commit related logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/pingcap/badger v1.5.1-0.20200714132513-80ba2000f159
 	github.com/pingcap/check v0.0.0-20200212061837-5e12011dc712
 	github.com/pingcap/errors v0.11.5-0.20190809092503-95897b64e011
-	github.com/pingcap/kvproto v0.0.0-20200630051533-f735bcd8f9f9
+	github.com/pingcap/kvproto v0.0.0-20200706115936-1e0910aabe6c
 	github.com/pingcap/log v0.0.0-20200511115504-543df19646ad
 	github.com/pingcap/pd/v4 v4.0.0-rc.2.0.20200520083007-2c251bd8f181
 	github.com/pingcap/tidb v1.1.0-beta.0.20200708115304-a99fdc098cb3

--- a/go.sum
+++ b/go.sum
@@ -492,8 +492,9 @@ github.com/pingcap/kvproto v0.0.0-20200518112156-d4aeb467de29 h1:NpW1OuYrIl+IQrS
 github.com/pingcap/kvproto v0.0.0-20200518112156-d4aeb467de29/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/kvproto v0.0.0-20200608081027-d02a6f65e956 h1:G4ekqFoMUusFnlPglbhifaZKcuJjDgkpdgaDywLL11E=
 github.com/pingcap/kvproto v0.0.0-20200608081027-d02a6f65e956/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
-github.com/pingcap/kvproto v0.0.0-20200630051533-f735bcd8f9f9 h1:2w4StpDuyXkAtg5wHTDtkqO71+spYbN4J53ARfyOAo4=
 github.com/pingcap/kvproto v0.0.0-20200630051533-f735bcd8f9f9/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
+github.com/pingcap/kvproto v0.0.0-20200706115936-1e0910aabe6c h1:VnLpCAxMAeDxc7HXTetwDQB+/MtDQjHAOBsd4QnGVwA=
+github.com/pingcap/kvproto v0.0.0-20200706115936-1e0910aabe6c/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9 h1:AJD9pZYm72vMgPcQDww9rkZ1DnWfl0pXV3BOWlkYIjA=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd h1:CV3VsP3Z02MVtdpTMfEgRJ4T9NGgGTxdHpJerent7rM=

--- a/tikv/errors.go
+++ b/tikv/errors.go
@@ -22,21 +22,23 @@ import (
 // ErrLocked is returned when trying to Read/Write on a locked key. Client should
 // backoff or cleanup the lock then retry.
 type ErrLocked struct {
-	Key      []byte
-	Primary  []byte
-	StartTS  uint64
-	TTL      uint64
-	LockType uint8
+	Key         []byte
+	Primary     []byte
+	StartTS     uint64
+	TTL         uint64
+	LockType    uint8
+	minCommitTS uint64
 }
 
 // BuildLockErr generates ErrKeyLocked objects
-func BuildLockErr(key []byte, primaryKey []byte, startTS uint64, TTL uint64, lockType uint8) *ErrLocked {
+func BuildLockErr(key []byte, primaryKey []byte, startTS uint64, TTL uint64, lockType uint8, minCommitTS uint64) *ErrLocked {
 	errLocked := &ErrLocked{
-		Key:      key,
-		Primary:  primaryKey,
-		StartTS:  startTS,
-		TTL:      TTL,
-		LockType: lockType,
+		Key:         key,
+		Primary:     primaryKey,
+		StartTS:     startTS,
+		TTL:         TTL,
+		LockType:    lockType,
+		minCommitTS: minCommitTS,
 	}
 	return errLocked
 }


### PR DESCRIPTION
Try to implement these async commit protocol related features:
- Update `kvproto`.
- Return `minCommitTS` in `Prewrite` response, fetching new ts from PD.
- `CheckTxnStatus` related change.
- Return `minCommitTS` in lock error information.

Tests:
- Unit tests.
- Simple demo with TiDB changes using async commit protocol.