### PR TITLE
safe copy lock key when build lock error

### DIFF
--- a/tikv/mvcc.go
+++ b/tikv/mvcc.go
@@ -1010,7 +1010,7 @@ func checkLock(lock mvcc.MvccLock, key []byte, startTS uint64, resolved []uint64
 	isWriteLock := lock.Op == uint8(kvrpcpb.Op_Put) || lock.Op == uint8(kvrpcpb.Op_Del)
 	isPrimaryGet := startTS == maxSystemTS && bytes.Equal(lock.Primary, key)
 	if lockVisible && isWriteLock && !isPrimaryGet {
-		return BuildLockErr(key, lock.Primary, lock.StartTS, uint64(lock.TTL), lock.Op, lock.MinCommitTS)
+		return BuildLockErr(safeCopy(key), lock.Primary, lock.StartTS, uint64(lock.TTL), lock.Op, lock.MinCommitTS)
 	}
 	return nil
 }


### PR DESCRIPTION
The input `key` of `checkLock` is a temporary buffer of the lock iterator, we should copy it to build lock error.