### PR TITLE
Fix missing lock fields in KeyError and forbid CheckTxnStatus pushing async commit locks

### DIFF
--- a/tikv/server.go
+++ b/tikv/server.go
@@ -198,7 +198,7 @@ func (svr *Server) KvPessimisticLock(ctx context.Context, req *kvrpcpb.Pessimist
 		errLocked := err.(*ErrLocked)
 		deadlockErr := &ErrDeadlock{
 			LockKey:         errLocked.Key,
-			LockTS:          errLocked.StartTS,
+			LockTS:          errLocked.Lock.StartTS,
 			DeadlockKeyHash: result.DeadlockResp.DeadlockKeyHash,
 		}
 		resp.Errors, resp.RegionError = convertToPBErrors(deadlockErr)
@@ -678,14 +678,7 @@ func convertToKeyError(err error) *kvrpcpb.KeyError {
 	switch x := causeErr.(type) {
 	case *ErrLocked:
 		return &kvrpcpb.KeyError{
-			Locked: &kvrpcpb.LockInfo{
-				PrimaryLock: x.Primary,
-				Key:         x.Key,
-				LockVersion: x.StartTS,
-				LockTtl:     x.TTL,
-				LockType:    kvrpcpb.Op(x.LockType),
-				MinCommitTs: x.minCommitTS,
-			},
+			Locked: x.Lock.ToLockInfo(x.Key),
 		}
 	case ErrRetryable:
 		return &kvrpcpb.KeyError{


### PR DESCRIPTION
CheckTxnStatus is changed to be aligned with TiKV.

I've tested locally that with this fix, the tests in https://github.com/pingcap/tidb/pull/20073 can pass.