### PR TITLE
adjust the position of finish req ctx in mpp request

### DIFF
--- a/tikv/server.go
+++ b/tikv/server.go
@@ -671,7 +671,9 @@ func (svr *Server) executeMPPDispatch(ctx context.Context, req *mpp.DispatchTask
 		if len(resp.OtherError) > 0 {
 			handler.Err = errors.New(resp.OtherError)
 		}
-		reqCtx.finish()
+		if reqCtx != nil {
+			reqCtx.finish()
+		}
 	}()
 	return nil
 }

--- a/tikv/server.go
+++ b/tikv/server.go
@@ -648,7 +648,6 @@ func (svr *Server) executeMPPDispatch(ctx context.Context, req *mpp.DispatchTask
 		if err != nil {
 			return errors.Trace(err)
 		}
-		defer reqCtx.finish()
 	}
 	copReq := &coprocessor.Request{
 		Tp:      kv.ReqTypeDAG,
@@ -672,6 +671,7 @@ func (svr *Server) executeMPPDispatch(ctx context.Context, req *mpp.DispatchTask
 		if len(resp.OtherError) > 0 {
 			handler.Err = errors.New(resp.OtherError)
 		}
+		reqCtx.finish()
 	}()
 	return nil
 }


### PR DESCRIPTION
the finish of reqCtx will close the reader thoroughly. So we have to finish it after the execution ends.