### PR TITLE
optimize sequential write

### DIFF
--- a/sdb/table/sstable/table.go
+++ b/sdb/table/sstable/table.go
@@ -296,6 +296,14 @@ func (t *Table) HasOverlap(start, end []byte, includeEnd bool) bool {
 	return true
 }
 
+func (t *Table) SeekBlock(key []byte) int {
+	return t.idx.seekBlock(key)
+}
+
+func (t *Table) NumBlocks() int {
+	return t.idx.numBlocks()
+}
+
 type nIndex struct {
 	commonPrefix []byte
 	blockKeyOffs []uint32


### PR DESCRIPTION
If we detect a sequential write pattern by the mem-table, we choose the second latest mem-table's biggest key as the split key, then we only need to split one L1 file.

Fixes https://github.com/ngaut/unistore/issues/486