### PR TITLE
wait for shard pre-split before apply pre-split flush

### DIFF
--- a/sdb/compaction.go
+++ b/sdb/compaction.go
@@ -582,6 +582,11 @@ func (sdb *DB) applyFlush(shard *Shard, changeSet *sdbpb.ChangeSet) error {
 			return err
 		}
 	}
+	if changeSet.Stage == sdbpb.SplitStage_PRE_SPLIT_FLUSH_DONE {
+		for !shard.isSplitting() {
+			time.Sleep(time.Millisecond)
+		}
+	}
 	if err := sdb.manifest.writeChangeSet(changeSet); err != nil {
 		if err == errDupChange {
 			return nil


### PR DESCRIPTION
pre-split flush should be executed later than pre-split, or pre-split would fail.