### PR TITLE
use l0 key as the split key when the l0 tables size is larger than 30%

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -829,7 +829,7 @@ func (en *Engine) GetOpt() Options {
 	return en.opt
 }
 
-func (en *Engine) TriggerFlush(shard *Shard, skipCnt int) {
+func (en *Engine) TriggerFlush(shard *Shard, skipCnt int, isPreSplitStage bool) {
 	mems := shard.loadMemTables()
 	for i := len(mems.tables) - skipCnt - 1; i > 0; i-- {
 		memTbl := mems.tables[i]
@@ -840,7 +840,7 @@ func (en *Engine) TriggerFlush(shard *Shard, skipCnt int) {
 		}
 	}
 	if len(mems.tables) == 1 && mems.tables[0].Empty() {
-		if !shard.IsInitialFlushed() {
+		if !shard.IsInitialFlushed() || isPreSplitStage {
 			commitTS := shard.allocCommitTS()
 			memTbl := memtable.NewCFTable(en.numCFs)
 			memTbl.SetVersion(commitTS)

--- a/engine/table/sstable/table.go
+++ b/engine/table/sstable/table.go
@@ -317,6 +317,18 @@ func (t *Table) NumBlocks() int {
 	return t.idx.numBlocks()
 }
 
+func (t *Table) GetSuggestSplitKey() []byte {
+	numBlocks := t.NumBlocks()
+	if numBlocks > 0 {
+		diffKey := t.idx.blockDiffKey(numBlocks / 2)
+		splitKey := make([]byte, len(t.idx.commonPrefix)+len(diffKey))
+		copy(splitKey, t.idx.commonPrefix)
+		copy(splitKey[len(t.idx.commonPrefix):], diffKey)
+		return splitKey
+	}
+	return []byte{}
+}
+
 type nIndex struct {
 	commonPrefix []byte
 	blockKeyOffs []uint32

--- a/tikv/raftstore/peer.go
+++ b/tikv/raftstore/peer.go
@@ -735,8 +735,8 @@ func (p *Peer) OnRoleChanged(observer PeerEventObserver, ready *raft.Ready) {
 				p.leaderChecker.term.Store(p.Term())
 			}
 			store := p.Store()
-			p.Store().Engines.kv.TriggerFlush(shard, store.onGoingFlushCnt())
 			shardMeta := p.Store().GetEngineMeta()
+			p.Store().Engines.kv.TriggerFlush(shard, store.onGoingFlushCnt(), shardMeta.SplitStage == enginepb.SplitStage_PRE_SPLIT)
 			if shardMeta.SplitStage != enginepb.SplitStage_INITIAL {
 				seq := shardMeta.Seq
 				regionSched := store.regionSched


### PR DESCRIPTION
* Use l0 key as the split key when the l0 tables size is larger than 30%.
* Fix bug where recovery state could not continue to split.