### PR TITLE
calculate memory table timestamp using raft log index instead of meta sequence

### DIFF
--- a/engine/compaction.go
+++ b/engine/compaction.go
@@ -640,8 +640,8 @@ func (en *Engine) applyFlush(shard *Shard, changeSet *enginepb.ChangeSet) error 
 			return err
 		}
 		atomicAddL0(shard, tbl)
-		atomicRemoveMemTable(shard)
 	}
+	atomicRemoveMemTable(shard)
 	shard.setSplitStage(changeSet.Stage)
 	shard.setInitialFlushed()
 	return nil

--- a/engine/shard.go
+++ b/engine/shard.go
@@ -95,7 +95,7 @@ func newShard(props *enginepb.Properties, ver uint64, start, end []byte, opt *Op
 		shard.setMaxMemTableSize(int64(binary.LittleEndian.Uint64(val)))
 	}
 	shard.memTbls = new(unsafe.Pointer)
-	atomic.StorePointer(shard.memTbls, unsafe.Pointer(&memTables{}))
+	atomic.StorePointer(shard.memTbls, unsafe.Pointer(&memTables{tables: []*memtable.Table{memtable.NewCFTable(len(shard.cfs))}}))
 	shard.l0s = new(unsafe.Pointer)
 	atomic.StorePointer(shard.l0s, unsafe.Pointer(&l0Tables{}))
 	shard.sizeStats = new(unsafe.Pointer)

--- a/engine/shard.go
+++ b/engine/shard.go
@@ -143,8 +143,8 @@ func newShardForIngest(changeSet *enginepb.ChangeSet, opt *Options) *Shard {
 	shard.setInitialFlushed()
 	shard.baseTS = shardSnap.BaseTS
 	shard.metaSequence = changeSet.Sequence
-	log.S().Infof("ingest shard %d:%d maxMemTblSize %d, memTableTS %d",
-		changeSet.ShardID, changeSet.ShardVer, shard.getMaxMemTableSize(), shard.loadMemTableTS())
+	log.S().Infof("ingest shard %d:%d maxMemTblSize %d, stage %s, baseTS %d, metaSequence %d",
+		changeSet.ShardID, changeSet.ShardVer, shard.getMaxMemTableSize(), shard.GetSplitStage().String(), shard.baseTS, shard.metaSequence)
 	return shard
 }
 
@@ -454,10 +454,6 @@ func boundedMemSize(size int64) int64 {
 		size = maxMemSizeLowerLimit
 	}
 	return size
-}
-
-func (s *Shard) loadMemTableTS() uint64 {
-	return s.baseTS + atomic.LoadUint64(&s.metaSequence)
 }
 
 func (s *Shard) GetAllFiles() []uint64 {

--- a/engine/split.go
+++ b/engine/split.go
@@ -17,13 +17,10 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/ngaut/unistore/engine/dfs"
-	"sync/atomic"
 	"time"
-	"unsafe"
 
 	"github.com/ngaut/unistore/engine/fileutil"
 	"github.com/ngaut/unistore/engine/table"
-	"github.com/ngaut/unistore/engine/table/memtable"
 	"github.com/ngaut/unistore/engine/table/sstable"
 	"github.com/ngaut/unistore/enginepb"
 	"github.com/ngaut/unistore/scheduler"
@@ -323,10 +320,8 @@ func (en *Engine) buildSplitShards(oldShard *Shard, newShardsProps []*enginepb.P
 		} else {
 			shard.SetPassive(oldShard.IsPassive())
 		}
-		shard.memTbls = new(unsafe.Pointer)
-		atomic.StorePointer(shard.memTbls, unsafe.Pointer(&memTables{tables: []*memtable.Table{oldShard.loadSplittingMemTable(i)}}))
-		shard.l0s = new(unsafe.Pointer)
-		atomic.StorePointer(shard.l0s, unsafe.Pointer(new(l0Tables)))
+		memTbls := shard.loadMemTables()
+		memTbls.tables[0] = oldShard.loadSplittingMemTable(i)
 		newShards[i] = shard
 		if shard.ID == oldShard.ID {
 			shard.baseTS = oldShard.baseTS

--- a/engine/write.go
+++ b/engine/write.go
@@ -42,12 +42,6 @@ func (sl0s *l0Tables) totalSize() int64 {
 
 func (en *Engine) switchMemTable(shard *Shard, memTableTS uint64) *memtable.Table {
 	oldWritableMemTbl := shard.loadWritableMemTable()
-	if oldWritableMemTbl == nil {
-		oldWritableMemTbl = memtable.NewCFTable(en.numCFs)
-		atomicAddMemTable(shard.memTbls, oldWritableMemTbl)
-	} else if oldWritableMemTbl.Empty() {
-		oldWritableMemTbl = memtable.NewCFTable(en.numCFs)
-	}
 	newWritableMemTbl := memtable.NewCFTable(en.numCFs)
 	atomicAddMemTable(shard.memTbls, newWritableMemTbl)
 	oldWritableMemTbl.SetVersion(memTableTS)

--- a/engine/write.go
+++ b/engine/write.go
@@ -40,22 +40,20 @@ func (sl0s *l0Tables) totalSize() int64 {
 	return size
 }
 
-func (en *Engine) switchMemTable(shard *Shard, commitTS uint64) *memtable.Table {
-	writableMemTbl := shard.loadWritableMemTable()
-	if writableMemTbl == nil {
-		writableMemTbl = memtable.NewCFTable(en.numCFs)
-		atomicAddMemTable(shard.memTbls, writableMemTbl)
+func (en *Engine) switchMemTable(shard *Shard, memTableTS uint64) *memtable.Table {
+	oldWritableMemTbl := shard.loadWritableMemTable()
+	if oldWritableMemTbl == nil {
+		oldWritableMemTbl = memtable.NewCFTable(en.numCFs)
+		atomicAddMemTable(shard.memTbls, oldWritableMemTbl)
+	} else if oldWritableMemTbl.Empty() {
+		oldWritableMemTbl = memtable.NewCFTable(en.numCFs)
 	}
-	if writableMemTbl.Empty() {
-		writableMemTbl = memtable.NewCFTable(en.numCFs)
-	} else {
-		newMemTable := memtable.NewCFTable(en.numCFs)
-		atomicAddMemTable(shard.memTbls, newMemTable)
-	}
-	writableMemTbl.SetVersion(commitTS)
+	newWritableMemTbl := memtable.NewCFTable(en.numCFs)
+	atomicAddMemTable(shard.memTbls, newWritableMemTbl)
+	oldWritableMemTbl.SetVersion(memTableTS)
 	log.S().Infof("shard %d:%d set mem-table version %d, empty %t, size %d",
-		shard.ID, shard.Ver, commitTS, writableMemTbl.Empty(), writableMemTbl.Size())
-	return writableMemTbl
+		shard.ID, shard.Ver, oldWritableMemTbl.GetVersion(), oldWritableMemTbl.Empty(), oldWritableMemTbl.Size())
+	return oldWritableMemTbl
 }
 
 func (en *Engine) Write(wb *WriteBatch) {
@@ -70,7 +68,8 @@ func (en *Engine) Write(wb *WriteBatch) {
 	}
 	memTbl := shard.loadWritableMemTable()
 	if memTbl == nil || memTbl.Size()+wb.estimatedSize > shard.getMaxMemTableSize() {
-		oldMemTbl := en.switchMemTable(shard, shard.loadMemTableTS())
+		memTableTS := commitTS
+		oldMemTbl := en.switchMemTable(shard, memTableTS)
 		en.scheduleFlushTask(shard, oldMemTbl)
 		memTbl = shard.loadWritableMemTable()
 	}


### PR DESCRIPTION
The current calculation method may have duplicate memory table timestamps. 
This PR fixes this bug.