### PR TITLE
refactor raft worker process for lower latency

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -111,8 +111,8 @@ var DefaultConf = Config{
 		RaftBaseTickInterval:     "1s",
 		RaftHeartbeatTicks:       2,
 		RaftElectionTimeoutTicks: 10,
-		ApplyWorkerCount:         4,
-		GRPCRaftConnNum:          2,
+		ApplyWorkerCount:         3,
+		GRPCRaftConnNum:          1,
 	},
 	Engine: Engine{
 		Path:                   "/tmp/badger",

--- a/tikv/raftstore/fsm_peer.go
+++ b/tikv/raftstore/fsm_peer.go
@@ -840,7 +840,6 @@ func (d *peerMsgHandler) onReadySplitRegion(derived *metapb.Region, regions []*m
 			newPeer.peer.HeartbeatPd(d.ctx.pdTaskSender)
 		}
 
-		newPeer.peer.Activate(d.ctx.applyMsgs)
 		meta.regions[newRegionID] = newRegion
 		d.ctx.router.register(newPeer)
 		_ = d.ctx.router.send(newRegionID, NewPeerMsg(MsgTypeStart, newRegionID, nil))


### PR DESCRIPTION
Before:

```
for each region {
  handleMsgs
}
for each region {
  newReady
}
for each region {
  handleReady
}
for each region {
  scheduleApply
}
```

After:
```
for each region {
  handleMsgs
  newReady
  handleReady
  scheduleApply
}
```


The apply worker can handle the task earlier, so the latency would be lower.

Since the apply task can be evenly spread within a period of time, the CPU utilization would be more stable.