### PR TITLE
limit the max batch size of a raft worker

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -46,6 +46,7 @@ type RaftStore struct {
 	RaftBaseTickInterval     string `toml:"raft-base-tick-interval"`     // raft-base-tick-interval in milliseconds
 	RaftHeartbeatTicks       int    `toml:"raft-heartbeat-ticks"`        // raft-heartbeat-ticks times
 	RaftElectionTimeoutTicks int    `toml:"raft-election-timeout-ticks"` // raft-election-timeout-ticks times
+	RaftMaxBatchCount        int    `toml:"raft-max-batch-count"`        // max raft message count for a batch.
 	ApplyWorkerCount         int    `toml:"apply-worker-count"`
 	GRPCRaftConnNum          int    `toml:"grpc-raft-conn-num"`
 	GitHash                  string
@@ -111,6 +112,7 @@ var DefaultConf = Config{
 		RaftBaseTickInterval:     "1s",
 		RaftHeartbeatTicks:       2,
 		RaftElectionTimeoutTicks: 10,
+		RaftMaxBatchCount:        256,
 		ApplyWorkerCount:         3,
 		GRPCRaftConnNum:          1,
 	},

--- a/tikv/raftstore/config.go
+++ b/tikv/raftstore/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	RaftMaxElectionTimeoutTicks int
 	RaftMaxSizePerMsg           uint64
 	RaftMaxInflightMsgs         int
+	RaftMaxBatchCount           int
 
 	// When the entry exceed the max size, reject to propose it.
 	RaftEntryMaxSize uint64
@@ -171,6 +172,7 @@ func NewDefaultConfig() *Config {
 		RaftMaxElectionTimeoutTicks:      0,
 		RaftMaxSizePerMsg:                1 * MB,
 		RaftMaxInflightMsgs:              256,
+		RaftMaxBatchCount:                256,
 		RaftEntryMaxSize:                 8 * MB,
 		RaftLogGCTickInterval:            10 * time.Second,
 		RaftEntryCacheLifeTime:           30 * time.Second,

--- a/tikv/raftstore/peer_worker.go
+++ b/tikv/raftstore/peer_worker.go
@@ -187,6 +187,9 @@ func (rw *raftWorker) receiveMsgs(closeCh <-chan struct{}) (quit bool) {
 		})
 	}
 	pending := len(rw.raftCh)
+	if pending > rw.raftCtx.cfg.RaftMaxBatchCount {
+		pending = rw.raftCtx.cfg.RaftMaxBatchCount
+	}
 	reqCount += pending
 	for i := 0; i < pending; i++ {
 		msg := <-rw.raftCh


### PR DESCRIPTION
So the follower response raft message can be sent sooner.