### PR TITLE
revert the max batch size config option.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -46,7 +46,6 @@ type RaftStore struct {
 	RaftBaseTickInterval     string `toml:"raft-base-tick-interval"`     // raft-base-tick-interval in milliseconds
 	RaftHeartbeatTicks       int    `toml:"raft-heartbeat-ticks"`        // raft-heartbeat-ticks times
 	RaftElectionTimeoutTicks int    `toml:"raft-election-timeout-ticks"` // raft-election-timeout-ticks times
-	RaftMaxBatchCount        int    `toml:"raft-max-batch-count"`        // max raft message count for a batch.
 	ApplyWorkerCount         int    `toml:"apply-worker-count"`
 	GRPCRaftConnNum          int    `toml:"grpc-raft-conn-num"`
 	GitHash                  string
@@ -112,7 +111,6 @@ var DefaultConf = Config{
 		RaftBaseTickInterval:     "1s",
 		RaftHeartbeatTicks:       2,
 		RaftElectionTimeoutTicks: 10,
-		RaftMaxBatchCount:        256,
 		ApplyWorkerCount:         3,
 		GRPCRaftConnNum:          1,
 	},

--- a/tikv/raftstore/config.go
+++ b/tikv/raftstore/config.go
@@ -40,7 +40,6 @@ type Config struct {
 	RaftMaxElectionTimeoutTicks int
 	RaftMaxSizePerMsg           uint64
 	RaftMaxInflightMsgs         int
-	RaftMaxBatchCount           int
 
 	// When the entry exceed the max size, reject to propose it.
 	RaftEntryMaxSize uint64
@@ -172,7 +171,6 @@ func NewDefaultConfig() *Config {
 		RaftMaxElectionTimeoutTicks:      0,
 		RaftMaxSizePerMsg:                1 * MB,
 		RaftMaxInflightMsgs:              256,
-		RaftMaxBatchCount:                256,
 		RaftEntryMaxSize:                 8 * MB,
 		RaftLogGCTickInterval:            10 * time.Second,
 		RaftEntryCacheLifeTime:           30 * time.Second,

--- a/tikv/raftstore/peer_worker.go
+++ b/tikv/raftstore/peer_worker.go
@@ -187,9 +187,6 @@ func (rw *raftWorker) receiveMsgs(closeCh <-chan struct{}) (quit bool) {
 		})
 	}
 	pending := len(rw.raftCh)
-	if pending > rw.raftCtx.cfg.RaftMaxBatchCount {
-		pending = rw.raftCtx.cfg.RaftMaxBatchCount
-	}
 	reqCount += pending
 	for i := 0; i < pending; i++ {
 		msg := <-rw.raftCh

--- a/tikv/server.go
+++ b/tikv/server.go
@@ -138,7 +138,6 @@ func setupRaftStoreConf(raftConf *raftstore.Config, conf *config.Config) {
 	raftConf.GrpcRaftConnNum = uint64(conf.RaftStore.GRPCRaftConnNum)
 	raftConf.StatusAddr = conf.Server.StatusAddr
 	raftConf.GitHash = conf.RaftStore.GitHash
-	raftConf.RaftMaxBatchCount = conf.RaftStore.RaftMaxBatchCount
 	for key, value := range conf.Server.Labels {
 		raftConf.Labels = append(raftConf.Labels, raftstore.StoreLabel{key, value})
 	}


### PR DESCRIPTION
Limit the max batch size has negative impact on the update-none-index workload performance.